### PR TITLE
[DPE-1633] Implement load_one method in ClientRegistry and its subclasses for single client retrieval

### DIFF
--- a/src/synapse_mcp/oauth/client_registry.py
+++ b/src/synapse_mcp/oauth/client_registry.py
@@ -85,18 +85,23 @@ class FileClientRegistry(ClientRegistry):
                 return None
             try:
                 data = json.loads(self._path.read_text())
-            except json.JSONDecodeError:  # pragma: no cover - defensive
+            except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+                logger.warning("Failed to parse client registry file %s: %s", self._path, exc)
                 return None
 
         item = data.get(client_id)
         if item is None:
             return None
-        return ClientRegistration(
-            client_id=item["client_id"],
-            client_secret=item.get("client_secret"),
-            redirect_uris=list(item.get("redirect_uris", [])),
-            grant_types=list(item.get("grant_types", [])),
-        )
+        try:
+            return ClientRegistration(
+                client_id=item["client_id"],
+                client_secret=item.get("client_secret"),
+                redirect_uris=list(item.get("redirect_uris", [])),
+                grant_types=list(item.get("grant_types", [])),
+            )
+        except (KeyError, TypeError) as exc:  # pragma: no cover - defensive
+            logger.warning("Malformed file client record for %s: %s", client_id, exc)
+            return None
 
     def save(self, registration: ClientRegistration) -> None:
         with self._lock:

--- a/src/synapse_mcp/oauth/client_registry.py
+++ b/src/synapse_mcp/oauth/client_registry.py
@@ -39,6 +39,9 @@ class ClientRegistry:
     def load_all(self) -> Iterable[ClientRegistration]:  # pragma: no cover - interface only
         raise NotImplementedError
 
+    def load_one(self, client_id: str) -> Optional[ClientRegistration]:  # pragma: no cover - interface only
+        raise NotImplementedError
+
     def save(self, registration: ClientRegistration) -> None:  # pragma: no cover - interface only
         raise NotImplementedError
 
@@ -75,6 +78,25 @@ class FileClientRegistry(ClientRegistry):
                 )
             )
         return registrations
+
+    def load_one(self, client_id: str) -> Optional[ClientRegistration]:
+        with self._lock:
+            if not self._path.exists():
+                return None
+            try:
+                data = json.loads(self._path.read_text())
+            except json.JSONDecodeError:  # pragma: no cover - defensive
+                return None
+
+        item = data.get(client_id)
+        if item is None:
+            return None
+        return ClientRegistration(
+            client_id=item["client_id"],
+            client_secret=item.get("client_secret"),
+            redirect_uris=list(item.get("redirect_uris", [])),
+            grant_types=list(item.get("grant_types", [])),
+        )
 
     def save(self, registration: ClientRegistration) -> None:
         with self._lock:
@@ -131,6 +153,27 @@ class RedisClientRegistry(ClientRegistry):
             except (KeyError, json.JSONDecodeError) as exc:  # pragma: no cover - defensive
                 logger.warning("Skipping malformed Redis client record: %s", exc)
         return registrations
+
+    def load_one(self, client_id: str) -> Optional[ClientRegistration]:
+        try:
+            raw = self._redis.hget(self._namespace, client_id)
+        except RedisError as exc:  # pragma: no cover - network failures
+            logger.warning("Failed to load client %s from Redis: %s", client_id, exc)
+            return None
+
+        if raw is None:
+            return None
+        try:
+            item = json.loads(raw)
+            return ClientRegistration(
+                client_id=item["client_id"],
+                client_secret=item.get("client_secret"),
+                redirect_uris=list(item.get("redirect_uris", [])),
+                grant_types=list(item.get("grant_types", [])),
+            )
+        except (KeyError, json.JSONDecodeError) as exc:  # pragma: no cover - defensive
+            logger.warning("Malformed Redis client record for %s: %s", client_id, exc)
+            return None
 
     def save(self, registration: ClientRegistration) -> None:
         try:

--- a/src/synapse_mcp/oauth/proxy.py
+++ b/src/synapse_mcp/oauth/proxy.py
@@ -25,6 +25,7 @@ class SessionAwareOAuthProxy(OAuthProxy):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._client_registry = create_client_registry(os.environ)
+        self._static_registrations = load_static_registrations()
         logger.debug(
             "SessionAwareOAuthProxy initialized with client registry %s",
             type(self._client_registry).__name__,
@@ -61,11 +62,13 @@ class SessionAwareOAuthProxy(OAuthProxy):
 
         # Persistent registry lookup (Redis hget or file read)
         registration = self._client_registry.load_one(client_id)
+        source = "persistent registry"
         if registration is None:
-            # Also check static registrations
-            for static in load_static_registrations():
+            # Also check static registrations (cached at init)
+            for static in self._static_registrations:
                 if static.client_id == client_id:
                     registration = static
+                    source = "static registrations"
                     break
         if registration is None:
             return None
@@ -80,7 +83,7 @@ class SessionAwareOAuthProxy(OAuthProxy):
         except Exception as exc:  # pragma: no cover - defensive
             logger.debug("Failed to cache client %s in local store: %s", client_id, exc)
 
-        logger.info("Resolved client %s from persistent registry", client_id)
+        logger.info("Resolved client %s from %s", client_id, source)
         return proxy_client
 
     async def register_client(self, client_info):

--- a/src/synapse_mcp/oauth/proxy.py
+++ b/src/synapse_mcp/oauth/proxy.py
@@ -75,14 +75,6 @@ class SessionAwareOAuthProxy(OAuthProxy):
 
         proxy_client = self._registration_to_proxy_client(registration)
 
-        # Cache into _client_store so subsequent lookups in this
-        # container's lifetime (e.g. /consent, /token in the same
-        # auth flow) hit the local store instead of Redis.
-        try:
-            await self._client_store.put(key=client_id, value=proxy_client)
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.debug("Failed to cache client %s in local store: %s", client_id, exc)
-
         logger.info("Resolved client %s from %s", client_id, source)
         return proxy_client
 

--- a/src/synapse_mcp/oauth/proxy.py
+++ b/src/synapse_mcp/oauth/proxy.py
@@ -10,7 +10,6 @@ from fastmcp.server.auth.oauth_proxy import ProxyDCRClient
 from mcp.server.auth.provider import OAuthClientInformationFull
 from pydantic import AnyUrl, TypeAdapter
 
-from ..session_storage import create_session_storage
 from .client_registry import (
     ClientRegistration,
     create_client_registry,
@@ -21,15 +20,13 @@ logger = logging.getLogger("synapse_mcp.oauth")
 
 
 class SessionAwareOAuthProxy(OAuthProxy):
-    """OAuth proxy that mirrors tokens into session storage."""
+    """OAuth proxy with persistent client registry backed by Redis/file."""
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self._session_storage = create_session_storage()
         self._client_registry = create_client_registry(os.environ)
         logger.debug(
-            "SessionAwareOAuthProxy initialized with session storage %s and client registry %s",
-            type(self._session_storage).__name__,
+            "SessionAwareOAuthProxy initialized with client registry %s",
             type(self._client_registry).__name__,
         )
 
@@ -73,8 +70,18 @@ class SessionAwareOAuthProxy(OAuthProxy):
         if registration is None:
             return None
 
+        proxy_client = self._registration_to_proxy_client(registration)
+
+        # Cache into _client_store so subsequent lookups in this
+        # container's lifetime (e.g. /consent, /token in the same
+        # auth flow) hit the local store instead of Redis.
+        try:
+            await self._client_store.put(key=client_id, value=proxy_client)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("Failed to cache client %s in local store: %s", client_id, exc)
+
         logger.info("Resolved client %s from persistent registry", client_id)
-        return self._registration_to_proxy_client(registration)
+        return proxy_client
 
     async def register_client(self, client_info):
         # Ensure grant_types includes refresh_token — many MCP clients
@@ -135,150 +142,7 @@ class SessionAwareOAuthProxy(OAuthProxy):
                     logger.debug(
                         "Removed empty state parameter from callback redirect")
 
-        if result:
-            try:
-                await self._map_new_tokens_to_users()
-            except Exception as exc:  # pragma: no cover - defensive
-                logger.warning("Failed to map tokens to users: %s", exc)
-        else:
-            logger.debug(
-                "No result returned from super()._handle_idp_callback")
-
         return result
-
-    async def exchange_authorization_code(
-        self,
-        client: Any,
-        authorization_code: Any,
-    ):
-
-        existing_tokens = set(getattr(self, "_access_tokens", {}).keys())
-        token_response = await super().exchange_authorization_code(client, authorization_code)
-
-        try:
-            await self._map_new_tokens_to_users()
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.warning(
-                "Failed to map tokens to users after exchange: %s", exc)
-
-        access_tokens = getattr(self, "_access_tokens", {})
-        new_tokens = [
-            token for token in access_tokens if token not in existing_tokens]
-        logger.debug("New tokens from exchange: %s", [
-                     t[:8] + "***" for t in new_tokens])
-
-        return token_response
-
-    async def _map_new_tokens_to_users(self) -> None:
-        existing_users = await self._session_storage.get_all_user_subjects()
-        access_tokens = getattr(self, "_access_tokens", {})
-        known_attrs = [attr for attr in dir(
-            self) if "token" in attr.lower() and not attr.startswith("__")]
-        logger.debug(
-            "_map_new_tokens_to_users: existing_users=%s tokens=%s token_attrs=%s",
-            existing_users,
-            [t[:8] + "***" for t in access_tokens],
-            {attr: _summarize_token_attr(attr, getattr(
-                self, attr, None)) for attr in known_attrs},
-        )
-        unmapped_tokens = [token for token in access_tokens if await self._session_storage.find_user_by_token(token) is None]
-        logger.debug("Unmapped tokens: %s", [
-                     t[:8] + "***" for t in unmapped_tokens])
-
-        for token_key in unmapped_tokens:
-            try:
-                import jwt
-
-                decoded = jwt.decode(token_key, options={
-                                     "verify_signature": False})
-                user_subject = decoded.get("sub")
-                if user_subject:
-                    await self._session_storage.set_user_token(user_subject, token_key, ttl_seconds=3600)
-                    logger.info("Mapped token %s*** to user %s",
-                                token_key[:20], user_subject)
-                else:
-                    logger.warning(
-                        "Token %s*** has no subject claim", token_key[:20])
-            except Exception as exc:  # pragma: no cover - decoding failures
-                logger.warning("Failed to decode token %s***: %s",
-                               token_key[:20], exc)
-
-    async def get_user_token(self, user_subject: str) -> Optional[str]:
-        token_key = await self._session_storage.get_user_token(user_subject)
-        if token_key and token_key in self._access_tokens:
-            return token_key
-        return None
-
-    async def cleanup_user_tokens(self, user_subject: str) -> None:
-        token_key = await self._session_storage.get_user_token(user_subject)
-        if token_key:
-            if token_key in self._access_tokens:
-                del self._access_tokens[token_key]
-            await self._session_storage.remove_user_token(user_subject)
-            logger.info("Cleaned up token for user %s", user_subject)
-
-    async def cleanup_expired_tokens(self) -> None:
-        await self._session_storage.cleanup_expired_tokens()
-
-        existing_users = await self._session_storage.get_all_user_subjects()
-        mapped_tokens = {
-            token
-            for user_subject in existing_users
-            for token in [await self._session_storage.get_user_token(user_subject)]
-            if token
-        }
-
-        orphaned = [token for token in list(
-            self._access_tokens.keys()) if token not in mapped_tokens]
-        for token in orphaned:
-            if self._is_token_old_enough_to_cleanup(token):
-                del self._access_tokens[token]
-
-        if orphaned:
-            logger.info(
-                "Cleaned up %s orphaned tokens from OAuth proxy", len(orphaned))
-
-    def _is_token_old_enough_to_cleanup(self, token: str, min_age_seconds: int = 30) -> bool:
-        try:
-            import jwt
-            from datetime import datetime, timezone
-
-            decoded = jwt.decode(token, options={"verify_signature": False})
-            issued_at = decoded.get("iat")
-            if not issued_at:
-                return True
-            token_age = datetime.now(timezone.utc).timestamp() - issued_at
-            if token_age <= min_age_seconds:
-                logger.debug(
-                    "Token is only %.1fs old, keeping for now", token_age)
-                return False
-            return True
-        except Exception as exc:  # pragma: no cover - decoding failures
-            logger.debug(
-                "Error checking token age, assuming old enough: %s", exc)
-            return True
-
-    async def iter_user_tokens(self) -> list[tuple[str, str]]:
-        """Return all known (subject, token) pairs from storage."""
-
-        tokens: list[tuple[str, str]] = []
-        subjects = await self._session_storage.get_all_user_subjects()
-        for subject in subjects:
-            token = await self._session_storage.get_user_token(subject)
-            if token:
-                tokens.append((subject, token))
-        logger.debug("iter_user_tokens -> %s",
-                     [(sub, tok[:8] + "***") for sub, tok in tokens])
-        return tokens
-
-    async def get_token_for_current_user(self) -> Optional[tuple[str, Optional[str]]]:
-        """Return a token/subject pair when a single active user is known."""
-
-        tokens = await self.iter_user_tokens()
-        if len(tokens) == 1:
-            subject, token = tokens[0]
-            return token, subject
-        return None
 
 
 def _extract_secret(secret: Any) -> Optional[str]:
@@ -288,46 +152,6 @@ def _extract_secret(secret: Any) -> Optional[str]:
         return secret.get_secret_value()  # type: ignore[attr-defined]
     except AttributeError:
         return secret  # type: ignore[return-value]
-
-
-def _mask_token(token: Optional[str]) -> Optional[str]:
-    if not token:
-        return token
-    return token[:8] + "***"
-
-
-def _summarize_token_attr(attr: str, value: Any) -> Any:
-    if value is None:
-        return None
-
-    if attr == "_access_tokens" and isinstance(value, dict):
-        summary: dict[str, dict[str, Any]] = {}
-        for token, data in value.items():
-            masked = _mask_token(token) or "<missing>"
-            summary[masked] = {
-                "client_id": getattr(data, "client_id", None),
-                "scopes": getattr(data, "scopes", None),
-                "expires_at": getattr(data, "expires_at", None),
-            }
-        return summary
-
-    if attr == "_refresh_tokens" and isinstance(value, dict):
-        summary = {}
-        for token, data in value.items():
-            masked = _mask_token(token) or "<missing>"
-            summary[masked] = {
-                "client_id": getattr(data, "client_id", None),
-                "scopes": getattr(data, "scopes", None),
-            }
-        return summary
-
-    if isinstance(value, dict):
-        return {"type": "dict", "count": len(value)}
-
-    if isinstance(value, (list, set, tuple)):
-        return {"type": type(value).__name__, "count": len(value)}
-
-    return type(value).__name__
 
 
 __all__ = ["SessionAwareOAuthProxy"]

--- a/src/synapse_mcp/oauth/proxy.py
+++ b/src/synapse_mcp/oauth/proxy.py
@@ -7,6 +7,7 @@ from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from fastmcp.server.auth import OAuthProxy
 from fastmcp.server.auth.oauth_proxy import ProxyDCRClient
+from mcp.server.auth.provider import OAuthClientInformationFull
 from pydantic import AnyUrl, TypeAdapter
 
 from ..session_storage import create_session_storage
@@ -26,54 +27,54 @@ class SessionAwareOAuthProxy(OAuthProxy):
         super().__init__(*args, **kwargs)
         self._session_storage = create_session_storage()
         self._client_registry = create_client_registry(os.environ)
-        if not hasattr(self, "_clients"):
-            # Guard against older fastmcp versions where OAuthProxy skipped initialization.
-            self._clients = {}
-        self._restore_registered_clients()
         logger.debug(
             "SessionAwareOAuthProxy initialized with session storage %s and client registry %s",
             type(self._session_storage).__name__,
             type(self._client_registry).__name__,
         )
 
-    def _restore_registered_clients(self) -> None:
-        try:
-            registrations = list(self._client_registry.load_all())
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.warning("Failed to load persisted OAuth clients: %s", exc)
-            return
-
-        # Merge statically configured clients (highest priority)
-        try:
-            registrations.extend(load_static_registrations())
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.warning("Failed to load static OAuth clients: %s", exc)
-
+    def _registration_to_proxy_client(self, record: ClientRegistration) -> ProxyDCRClient:
+        """Build a ProxyDCRClient from a persisted ClientRegistration."""
         default_grants = ["authorization_code", "refresh_token"]
+        adapter = TypeAdapter(List[AnyUrl])
+        redirect_source = record.redirect_uris if record.redirect_uris else [
+            "http://127.0.0.1"]
+        redirect_uris = adapter.validate_python(redirect_source)
+        return ProxyDCRClient(
+            client_id=record.client_id,
+            client_secret=record.client_secret,
+            redirect_uris=redirect_uris,
+            grant_types=record.grant_types or default_grants,
+            scope=self._default_scope_str,
+            token_endpoint_auth_method="none",
+            allowed_redirect_uri_patterns=self._allowed_client_redirect_uris,
+        )
 
-        for record in registrations:
-            if record.client_id in self._clients:
-                continue
-            try:
-                adapter = TypeAdapter(List[AnyUrl])
-                redirect_source = record.redirect_uris if record.redirect_uris else [
-                    "http://127.0.0.1"]
-                redirect_uris = adapter.validate_python(redirect_source)
-                proxy_client = ProxyDCRClient(
-                    client_id=record.client_id,
-                    client_secret=record.client_secret,
-                    redirect_uris=redirect_uris,
-                    grant_types=record.grant_types or default_grants,
-                    scope=self._default_scope_str,
-                    token_endpoint_auth_method="none",
-                    allowed_redirect_uri_patterns=self._allowed_client_redirect_uris,
-                )
-                self._clients[record.client_id] = proxy_client
-                logger.info("Restored registered OAuth client %s",
-                            record.client_id)
-            except Exception as exc:  # pragma: no cover - defensive
-                logger.warning(
-                    "Failed to restore OAuth client %s: %s", record.client_id, exc)
+    async def get_client(self, client_id: str) -> Optional[OAuthClientInformationFull]:
+        """Look up a registered client.
+
+        Checks FastMCP's in-process ``_client_store`` first (covers
+        clients registered during *this* process lifetime), then falls
+        back to the persistent registry (Redis / file) so that clients
+        survive container restarts without bulk-loading into memory.
+        """
+        client = await super().get_client(client_id)
+        if client is not None:
+            return client
+
+        # Persistent registry lookup (Redis hget or file read)
+        registration = self._client_registry.load_one(client_id)
+        if registration is None:
+            # Also check static registrations
+            for static in load_static_registrations():
+                if static.client_id == client_id:
+                    registration = static
+                    break
+        if registration is None:
+            return None
+
+        logger.info("Resolved client %s from persistent registry", client_id)
+        return self._registration_to_proxy_client(registration)
 
     async def register_client(self, client_info):
         # Ensure grant_types includes refresh_token — many MCP clients

--- a/tests/test_oauth_proxy.py
+++ b/tests/test_oauth_proxy.py
@@ -1,8 +1,7 @@
-"""Tests for the OAuth proxy with user-based token storage."""
+"""Tests for the OAuth proxy with persistent client registry."""
 
 import json
 from types import SimpleNamespace
-import sys
 
 import pytest
 from fastmcp.server.auth.oauth_proxy import OAuthClientInformationFull, OAuthProxy
@@ -37,39 +36,7 @@ class FakeRegistry:
         self.records.pop(client_id, None)
 
 
-class FakeStorage:
-    def __init__(self):
-        self.tokens = {}
-        self.set_calls = []
-        self.removed = []
-
-    async def get_all_user_subjects(self):
-        return set(self.tokens.keys())
-
-    async def find_user_by_token(self, token):
-        for subject, stored in self.tokens.items():
-            if stored == token:
-                return subject
-        return None
-
-    async def set_user_token(self, user_subject, access_token, ttl_seconds=3600):
-        self.tokens[user_subject] = access_token
-        self.set_calls.append((user_subject, access_token))
-
-    async def get_user_token(self, user_subject):
-        return self.tokens.get(user_subject)
-
-    async def remove_user_token(self, user_subject):
-        self.tokens.pop(user_subject, None)
-        self.removed.append(user_subject)
-
-    async def cleanup_expired_tokens(self):
-        return None
-
-
-def build_proxy(monkeypatch, storage, registry: FakeRegistry | None = None, token_verifier=None):
-    monkeypatch.setattr(
-        "synapse_mcp.oauth.proxy.create_session_storage", lambda: storage)
+def build_proxy(monkeypatch, registry: FakeRegistry | None = None, token_verifier=None):
     if registry is not None:
         monkeypatch.setattr(
             "synapse_mcp.oauth.proxy.create_client_registry", lambda *_, **__: registry)
@@ -87,51 +54,8 @@ def build_proxy(monkeypatch, storage, registry: FakeRegistry | None = None, toke
 
 
 @pytest.mark.anyio
-async def test_map_new_tokens_populates_storage(monkeypatch):
-    storage = FakeStorage()
-    proxy = build_proxy(monkeypatch, storage, FakeRegistry())
-    proxy._access_tokens = {"token123": object()}
-
-    dummy_jwt = SimpleNamespace(
-        decode=lambda token, options=None: {"sub": "user-1"})
-    monkeypatch.setitem(sys.modules, "jwt", dummy_jwt)
-
-    await proxy._map_new_tokens_to_users()
-
-    assert storage.tokens["user-1"] == "token123"
-
-
-@pytest.mark.anyio
-async def test_get_token_for_current_user(monkeypatch):
-    storage = FakeStorage()
-    storage.tokens["user-1"] = "token123"
-    proxy = build_proxy(monkeypatch, storage, FakeRegistry())
-
-    result = await proxy.get_token_for_current_user()
-    assert result == ("token123", "user-1")
-    assert await proxy.iter_user_tokens() == [("user-1", "token123")]
-
-
-@pytest.mark.anyio
-async def test_cleanup_expired_tokens_removes_orphans(monkeypatch):
-    storage = FakeStorage()
-    storage.tokens["user-1"] = "token123"
-    proxy = build_proxy(monkeypatch, storage, FakeRegistry())
-
-    proxy._access_tokens = {"token123": object(), "token999": object()}
-    monkeypatch.setattr(SessionAwareOAuthProxy,
-                        "_is_token_old_enough_to_cleanup", lambda self, token: True)
-
-    await proxy.cleanup_expired_tokens()
-
-    assert "token999" not in proxy._access_tokens
-    assert "token123" in proxy._access_tokens
-
-
-@pytest.mark.anyio
 async def test_handle_callback_sanitizes_none_state(monkeypatch):
-    storage = FakeStorage()
-    proxy = build_proxy(monkeypatch, storage, FakeRegistry())
+    proxy = build_proxy(monkeypatch, FakeRegistry())
 
     async def fake_handle(self, request, *args, **kwargs):
         return RedirectResponse("http://app/callback?code=new-token&state=None")
@@ -151,8 +75,7 @@ async def test_handle_callback_sanitizes_none_state(monkeypatch):
 
 @pytest.mark.anyio
 async def test_handle_callback_preserves_valid_state(monkeypatch):
-    storage = FakeStorage()
-    proxy = build_proxy(monkeypatch, storage, FakeRegistry())
+    proxy = build_proxy(monkeypatch, FakeRegistry())
 
     async def fake_handle(self, request, *args, **kwargs):
         return RedirectResponse("http://app/callback?code=token&state=valid123")
@@ -171,8 +94,7 @@ async def test_client_registry_persists_across_instances(monkeypatch, tmp_path):
     registry_path = tmp_path / "clients.json"
     monkeypatch.setenv("SYNAPSE_MCP_CLIENT_REGISTRY_PATH", str(registry_path))
 
-    storage = FakeStorage()
-    proxy = build_proxy(monkeypatch, storage)
+    proxy = build_proxy(monkeypatch)
 
     client_info = OAuthClientInformationFull(
         client_id="client-xyz",
@@ -186,8 +108,7 @@ async def test_client_registry_persists_across_instances(monkeypatch, tmp_path):
     saved = json.loads(registry_path.read_text())
     assert "client-xyz" in saved
 
-    new_storage = FakeStorage()
-    new_proxy = build_proxy(monkeypatch, new_storage)
+    new_proxy = build_proxy(monkeypatch)
 
     assert await new_proxy.get_client("client-xyz") is not None
 
@@ -204,8 +125,7 @@ async def test_static_clients_loaded_from_env(monkeypatch):
     )
     monkeypatch.setenv("SYNAPSE_MCP_STATIC_CLIENTS", payload)
 
-    storage = FakeStorage()
-    proxy = build_proxy(monkeypatch, storage, FakeRegistry())
+    proxy = build_proxy(monkeypatch, FakeRegistry())
 
     assert await proxy.get_client("static-client") is not None
 
@@ -272,11 +192,40 @@ async def test_get_client_falls_back_to_registry(monkeypatch):
         grant_types=["authorization_code", "refresh_token"],
     )
 
-    storage = FakeStorage()
-    proxy = build_proxy(monkeypatch, storage, registry)
+    proxy = build_proxy(monkeypatch, registry)
 
     result = await proxy.get_client("persisted-client")
     assert result is not None
     assert result.client_id == "persisted-client"
 
     assert await proxy.get_client("nonexistent") is None
+
+
+@pytest.mark.anyio
+async def test_get_client_caches_registry_hit_in_local_store(monkeypatch):
+    """After resolving a client from the persistent registry, subsequent
+    lookups should be served from the local _client_store without hitting
+    the registry again."""
+    from synapse_mcp.oauth.client_registry import ClientRegistration
+
+    registry = FakeRegistry()
+    registry.records["cached-client"] = ClientRegistration(
+        client_id="cached-client",
+        client_secret=None,
+        redirect_uris=["http://127.0.0.1:5000/callback"],
+        grant_types=["authorization_code", "refresh_token"],
+    )
+
+    proxy = build_proxy(monkeypatch, registry)
+
+    # First call — should fall back to registry
+    result1 = await proxy.get_client("cached-client")
+    assert result1 is not None
+
+    # Remove from registry — simulates registry being unreachable
+    del registry.records["cached-client"]
+
+    # Second call — should be served from local _client_store
+    result2 = await proxy.get_client("cached-client")
+    assert result2 is not None
+    assert result2.client_id == "cached-client"

--- a/tests/test_oauth_proxy.py
+++ b/tests/test_oauth_proxy.py
@@ -27,6 +27,9 @@ class FakeRegistry:
     def load_all(self):
         return list(self.records.values())
 
+    def load_one(self, client_id):
+        return self.records.get(client_id)
+
     def save(self, registration):
         self.records[registration.client_id] = registration
 
@@ -186,7 +189,7 @@ async def test_client_registry_persists_across_instances(monkeypatch, tmp_path):
     new_storage = FakeStorage()
     new_proxy = build_proxy(monkeypatch, new_storage)
 
-    assert "client-xyz" in new_proxy._clients
+    assert await new_proxy.get_client("client-xyz") is not None
 
 
 @pytest.mark.anyio
@@ -204,7 +207,7 @@ async def test_static_clients_loaded_from_env(monkeypatch):
     storage = FakeStorage()
     proxy = build_proxy(monkeypatch, storage, FakeRegistry())
 
-    assert "static-client" in proxy._clients
+    assert await proxy.get_client("static-client") is not None
 
 
 @pytest.mark.anyio
@@ -252,3 +255,28 @@ async def test_connection_auth_with_oauth_token(monkeypatch):
     client = connection_auth.get_synapse_client(ctx)
     assert isinstance(client, DummySynapse)
     assert client.logged_in == token
+
+
+@pytest.mark.anyio
+async def test_get_client_falls_back_to_registry(monkeypatch):
+    """A fresh proxy (empty _client_store) should resolve clients
+    that exist only in the persistent registry — simulates a
+    container restart where the DiskStore is wiped but Redis persists."""
+    from synapse_mcp.oauth.client_registry import ClientRegistration
+
+    registry = FakeRegistry()
+    registry.records["persisted-client"] = ClientRegistration(
+        client_id="persisted-client",
+        client_secret=None,
+        redirect_uris=["http://127.0.0.1:5000/callback"],
+        grant_types=["authorization_code", "refresh_token"],
+    )
+
+    storage = FakeStorage()
+    proxy = build_proxy(monkeypatch, storage, registry)
+
+    result = await proxy.get_client("persisted-client")
+    assert result is not None
+    assert result.client_id == "persisted-client"
+
+    assert await proxy.get_client("nonexistent") is None


### PR DESCRIPTION
# **Problem:**

  - There was a recent update to the FastMCP server that caused a regression on container restarts. After a container restart, previously registered OAuth clients become invisible to the get_client() lookup. Root cause: FastMCP 2.14.6 stores clients in _client_store (an encrypted DiskStore), but SessionAwareOAuthProxy._restore_registered_clients() writes to self._clients (a dict that FastMCP no longer reads). The DiskStore is ephemeral in Fargate containers, so after restart the clients are in Redis but never loaded into _client_store.


# **Solution:**

  - Change to load a single client from redis on demand instead of reloading all registered clients on startup of the container. The implication of this change is more traffic and communication with redis, however, the benefit is that the memory does not grow with more client registrations being added to the system, not every client is loaded back. Instead, clients are loaded back into memory as they communicate with the MCP server again.                                                                                                                                                       
  - Removed session-storage/token-mirroring code. The previous implementation stored user tokens in a separate session store that was coupled to the client registry restore path. With the move to on-demand client loading, that code and its associated tests became dead weight and have been removed.    

```mermaid
sequenceDiagram                                                                                                                                                                                    
      participant Client as MCP Client                                                                                                                                                                 
      participant WAF as AWS WAF                                                                                                                                                                       
      participant Proxy as SessionAwareOAuthProxy                                                                                                                                                      
      participant Store as _client_store<br/>(DiskStore, ephemeral)                                                                                                                                    
      participant Redis as Redis<br/>(persistent)           
      participant IdP as Synapse IdP                                                                                                                                                                   
                                                            
      Note over Client,IdP: REGISTRATION PHASE                                                                                                                                                         
                                                            
      Client->>WAF: POST /register                                                                                                                                                                     
      WAF->>Proxy: POST /register                           
      activate Proxy
      Proxy->>Proxy: register_client()                                                                                                                                                                 
      Proxy->>Store: super().register_client()<br/>put(client_id, ProxyDCRClient)
      Store-->>Proxy: stored ✓                                                                                                                                                                         
      Proxy->>Redis: _client_registry.save()<br/>hset(client_id, registration)
      Redis-->>Proxy: stored ✓                                                                                                                                                                         
      Proxy-->>Client: 201 Created                          
      deactivate Proxy                                                                                                                                                                                 
                                                            
      Note over Client,IdP: AUTHORIZE (same container — DiskStore hit)                                                                                                                                 
                                                            
      Client->>WAF: GET /authorize?client_id=X                                                                                                                                                         
      WAF->>Proxy: GET /authorize                           
      activate Proxy                                                                                                                                                                                   
      Proxy->>Store: super().get_client(X)                  
      Store-->>Proxy: ProxyDCRClient ✓                                                                                                                                                                 
      Note right of Proxy: Redis NOT consulted
      Proxy->>Proxy: authorize() → create transaction                                                                                                                                                  
      Proxy-->>Client: 302 → /consent                       
      deactivate Proxy                                                                                                                                                                                 
                                                            
      rect rgb(255, 240, 240)                                                                                                                                                                          
          Note over Store: ══ CONTAINER RESTARTS ══<br/>DiskStore WIPED<br/>Redis persists
      end                                                                                                                                                                                              
  
      Note over Client,IdP: AUTHORIZE (new container — Redis fallback + cache)                                                                                                                         
                                                            
      Client->>WAF: GET /authorize?client_id=X                                                                                                                                                         
      WAF->>Proxy: GET /authorize                           
      activate Proxy
      Proxy->>Store: super().get_client(X)
      Store-->>Proxy: None (wiped)
      Proxy->>Redis: load_one(X) → hget                                                                                                                                                                
      Redis-->>Proxy: ClientRegistration ✓                                                                                                                                                             
      Proxy->>Proxy: _registration_to_proxy_client()                                                                                                                                                   
      Proxy->>Store: _client_store.put(X, ProxyDCRClient)                                                                                                                                              
      Store-->>Proxy: cached ✓                              
      Proxy-->>Client: 302 → /consent                                                                                                                                                                  
      deactivate Proxy                                      
                                                                                                                                                                                                       
      Client->>WAF: GET /consent                            
      WAF->>Proxy: GET /consent
      activate Proxy
      Proxy->>Store: super().get_client(X)                                                                                                                                                             
      Store-->>Proxy: ProxyDCRClient ✓ (cached)
      Note right of Proxy: Redis NOT consulted                                                                                                                                                         
      Proxy-->>Client: 200 consent HTML                                                                                                                                                                
      deactivate Proxy
                                                                                                                                                                                                       
      Client->>IdP: GET /authorize (upstream)                                                                                                                                                          
      IdP-->>Client: 302 → callback
      Client->>Proxy: GET /oauth/callback?code=...                                                                                                                                                     
      Proxy->>IdP: POST /token (upstream exchange)                                                                                                                                                     
      IdP-->>Proxy: {access_token, refresh_token}
      Proxy->>Proxy: _handle_idp_callback()<br/>stores code in _code_store                                                                                                                             
      Proxy-->>Client: 302 → redirect_uri?code=LOCAL_CODE                                                                                                                                              
                                                                                                                                                                                                       
      Client->>WAF: POST /token (client_id=X, code=...)                                                                                                                                                
      WAF->>Proxy: POST /token                              
      activate Proxy                                                                                                                                                                                   
      Proxy->>Proxy: ClientAuthenticator.authenticate_request()
      Proxy->>Store: super().get_client(X)                                                                                                                                                             
      Store-->>Proxy: ProxyDCRClient ✓ (cached)
      Note right of Proxy: Redis NOT consulted                                                                                                                                                         
      Proxy->>Proxy: exchange_authorization_code()<br/>FastMCP issues its own JWT
      Proxy-->>Client: {access_token (JWT), refresh_token}                                                                                                                                             
      deactivate Proxy        
```

# **Testing:**

- Unit testing the changes, and will deploy to both dev and staging to verify changes.
