### PR TITLE
[DPE-1633] Add Redis storage creation for OAuth state with encryption support

### DIFF
--- a/src/synapse_mcp/oauth/factory.py
+++ b/src/synapse_mcp/oauth/factory.py
@@ -2,11 +2,8 @@
 
 import logging
 import os
+from collections.abc import Mapping
 from typing import Optional
-
-from cryptography.fernet import Fernet
-from fastmcp.server.auth.jwt_issuer import derive_jwt_key
-from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
 
 from .config import load_oauth_settings, should_skip_oauth
 from .jwt import SynapseJWTVerifier
@@ -95,7 +92,7 @@ def create_oauth_proxy(env: Optional[dict[str, str]] = None):
     return auth
 
 
-def _create_redis_storage(env: dict[str, str], client_secret: str):
+def _create_redis_storage(env: Mapping[str, str], client_secret: str):
     """Create a Redis-backed encrypted storage for OAuth state.
 
     When REDIS_URL is available, returns a FernetEncryptionWrapper around
@@ -105,13 +102,22 @@ def _create_redis_storage(env: dict[str, str], client_secret: str):
     """
     redis_url = env.get("REDIS_URL")
     if not redis_url:
-        logger.info("No REDIS_URL configured — using default ephemeral DiskStore for OAuth state")
+        logger.info(
+            "No REDIS_URL configured — using default ephemeral DiskStore "
+            "for OAuth state"
+        )
         return None
 
     try:
+        from cryptography.fernet import Fernet
+        from fastmcp.server.auth.jwt_issuer import derive_jwt_key
         from key_value.aio.stores.redis import RedisStore
+        from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
     except ImportError:
-        logger.warning("RedisStore not available — using default ephemeral DiskStore for OAuth state")
+        logger.warning(
+            "RedisStore not available — using default ephemeral DiskStore "
+            "for OAuth state"
+        )
         return None
 
     # Match FastMCP's two-step key derivation:

--- a/src/synapse_mcp/oauth/factory.py
+++ b/src/synapse_mcp/oauth/factory.py
@@ -114,8 +114,15 @@ def _create_redis_storage(env: dict[str, str], client_secret: str):
         logger.warning("RedisStore not available — using default ephemeral DiskStore for OAuth state")
         return None
 
-    encryption_key = derive_jwt_key(
+    # Match FastMCP's two-step key derivation:
+    # 1) client_secret -> jwt_signing_key (same as OAuthProxy.__init__)
+    # 2) jwt_signing_key -> storage_encryption_key
+    jwt_signing_key = derive_jwt_key(
         high_entropy_material=client_secret,
+        salt="fastmcp-jwt-signing-key",
+    )
+    encryption_key = derive_jwt_key(
+        high_entropy_material=jwt_signing_key.decode(),
         salt="fastmcp-storage-encryption-key",
     )
     redis_store = RedisStore(url=redis_url, default_collection="synapse-mcp-oauth")

--- a/src/synapse_mcp/oauth/factory.py
+++ b/src/synapse_mcp/oauth/factory.py
@@ -4,6 +4,10 @@ import logging
 import os
 from typing import Optional
 
+from cryptography.fernet import Fernet
+from fastmcp.server.auth.jwt_issuer import derive_jwt_key
+from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
+
 from .config import load_oauth_settings, should_skip_oauth
 from .jwt import SynapseJWTVerifier
 from .proxy import SessionAwareOAuthProxy
@@ -75,6 +79,8 @@ def create_oauth_proxy(env: Optional[dict[str, str]] = None):
         required_scopes=["openid", "view"],
     )
 
+    client_storage = _create_redis_storage(env_dict, settings.client_secret)
+
     auth = SessionAwareOAuthProxy(
         upstream_authorization_endpoint=endpoints["authorization_endpoint"],
         upstream_token_endpoint=endpoints["token_endpoint"],
@@ -83,9 +89,42 @@ def create_oauth_proxy(env: Optional[dict[str, str]] = None):
         redirect_path="/oauth/callback",
         token_verifier=jwt_verifier,
         base_url=settings.server_url,
+        client_storage=client_storage,
     )
 
     return auth
+
+
+def _create_redis_storage(env: dict[str, str], client_secret: str):
+    """Create a Redis-backed encrypted storage for OAuth state.
+
+    When REDIS_URL is available, returns a FernetEncryptionWrapper around
+    a RedisStore so that upstream tokens, JTI mappings, and refresh tokens
+    survive container restarts. Falls back to None (FastMCP's default
+    ephemeral DiskStore) when Redis is not configured.
+    """
+    redis_url = env.get("REDIS_URL")
+    if not redis_url:
+        logger.info("No REDIS_URL configured — using default ephemeral DiskStore for OAuth state")
+        return None
+
+    try:
+        from key_value.aio.stores.redis import RedisStore
+    except ImportError:
+        logger.warning("RedisStore not available — using default ephemeral DiskStore for OAuth state")
+        return None
+
+    encryption_key = derive_jwt_key(
+        high_entropy_material=client_secret,
+        salt="fastmcp-storage-encryption-key",
+    )
+    redis_store = RedisStore(url=redis_url, default_collection="synapse-mcp-oauth")
+    storage = FernetEncryptionWrapper(
+        key_value=redis_store,
+        fernet=Fernet(key=encryption_key),
+    )
+    logger.info("Using Redis-backed encrypted storage for OAuth state")
+    return storage
 
 
 __all__ = ["create_oauth_proxy"]

--- a/tests/test_oauth_factory.py
+++ b/tests/test_oauth_factory.py
@@ -1,7 +1,5 @@
 """Tests for the OAuth factory's Redis storage creation."""
 
-import pytest
-
 from synapse_mcp.oauth.factory import _create_redis_storage
 
 
@@ -16,7 +14,7 @@ def test_create_redis_storage_returns_none_with_empty_redis_url():
     assert result is None
 
 
-def test_create_redis_storage_returns_encrypted_wrapper(monkeypatch):
+def test_create_redis_storage_returns_encrypted_wrapper():
     """With REDIS_URL, factory returns a FernetEncryptionWrapper around RedisStore."""
     from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
 

--- a/tests/test_oauth_factory.py
+++ b/tests/test_oauth_factory.py
@@ -1,0 +1,28 @@
+"""Tests for the OAuth factory's Redis storage creation."""
+
+import pytest
+
+from synapse_mcp.oauth.factory import _create_redis_storage
+
+
+def test_create_redis_storage_returns_none_without_redis_url():
+    """Without REDIS_URL, factory returns None (falls back to DiskStore)."""
+    result = _create_redis_storage({}, "test-secret")
+    assert result is None
+
+
+def test_create_redis_storage_returns_none_with_empty_redis_url():
+    result = _create_redis_storage({"REDIS_URL": ""}, "test-secret")
+    assert result is None
+
+
+def test_create_redis_storage_returns_encrypted_wrapper(monkeypatch):
+    """With REDIS_URL, factory returns a FernetEncryptionWrapper around RedisStore."""
+    from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
+
+    storage = _create_redis_storage(
+        {"REDIS_URL": "redis://localhost:6379"},
+        "test-secret-with-enough-entropy",
+    )
+    assert storage is not None
+    assert isinstance(storage, FernetEncryptionWrapper)


### PR DESCRIPTION
  **Problem:**
                                                                                                                                                                                                       
  When the ECS container restarts (deployment, scaling, crash recovery), all authenticated users are forced to re-authenticate through the full Synapse OAuth browser flow. This happens because FastMCP 2.14.6 stores all OAuth state — upstream tokens, JTI mappings, refresh tokens, authorization codes — in an encrypted DiskStore. In Fargate, the container's disk is ephemeral and wiped on every restart.
                                                                                                                                                                                                       
The previous token-mirroring approach (removed in #31) relied on accessing self._access_tokens, a plain Python dict that FastMCP 2.14.6 replaced with opaque PydanticAdapter collections backed by the DiskStore. After the upgrade, getattr(self, "_access_tokens", {}) silently returned an empty dict, making the mirroring a no-op — tokens were never actually being persisted to Redis. PR #31correctly identified this as dead code and removed it, but did not replace it with the correct integration point.                                                                                    


  **Migration Impact:**                                                                                                                                                                                    
                                                                                                                                                                                                       
  Deploying this change requires a one-time re-authentication for all active users. Existing sessions cannot be preserved across the deploy because:
                                                                                                                                                                                                       
  1. Old session data (synapse_mcp:session:user:{subject} keys) stores simple user_subject → access_token mappings                                                                                     
  2. FastMCP's internal stores expect encrypted UpstreamTokenSet, JTIMapping, and RefreshTokenMetadata objects in mcp-*:: prefixed keys                                                                
  3. The data structures are incompatible and there is no migration path between them                                                                                                                  
                                                                                                                                                                                                       
  What happens on deploy:                                                                                                                                                                              
  - ECS rolls out new containers — the old ephemeral DiskStore is wiped                                                                                                                                
  - The new Redis-backed store starts empty (different key namespace)                                                                                                                                  
  - Old synapse_mcp:session:* keys in Redis are orphaned (nothing reads them)
  - All users re-authenticate once through the Synapse OAuth flow                                                                                                                                      
  - After that, sessions survive future container restarts         

  **Solution:**

  FastMCP's OAuthProxy accepts a client_storage: AsyncKeyValue constructor parameter. When provided, all internal stores (_upstream_token_store, _jti_mapping_store, _refresh_token_store, _code_store, _client_store) use this backend instead of the default ephemeral DiskStore.
                                                                                                                                                                                                       
  The fix passes a Redis-backed RedisStore (from the key_value library, already a transitive dependency via FastMCP) wrapped with FernetEncryptionWrapper as client_storage. This makes all OAuth state persist in Redis automatically — no custom mirroring logic needed. When REDIS_URL is not set (local dev), behavior is unchanged.
                                                                                                                                                                                                       
  Files changed:                                            
  - src/synapse_mcp/oauth/factory.py — Added _create_redis_storage() and pass result as client_storage to SessionAwareOAuthProxy
  - tests/test_oauth_factory.py — New tests for Redis storage creation and fallback behavior                                                                                                           
  
  **Testing:**                                                                                                                                                                                             
                                                            
  - All 63 existing tests pass with no changes                                                                                                                                                         
  - New unit tests verify:                                  
    - _create_redis_storage() returns None without REDIS_URL (DiskStore fallback)                                                                                                                      
    - _create_redis_storage() returns FernetEncryptionWrapper when REDIS_URL is set                                                                                                                    
  - Deploy to dev and verify:                                                                                                                                                                          
    - Authenticate via OAuth                                                                                                                                                                           
    - Restart ECS container                                                                                                                                                                            
    - Confirm MCP client resumes without re-authentication  
    - Verify token keys appear in Redis with appropriate TTLs    