### PR TITLE
Offload blocking synapseclient calls to thread pool

### DIFF
--- a/src/synapse_mcp/connection_auth.py
+++ b/src/synapse_mcp/connection_auth.py
@@ -27,6 +27,8 @@ and authenticates the synapseclient.
 import logging
 import os
 from typing import Optional, Dict, Any
+
+import anyio.to_thread
 from fastmcp import Context
 import synapseclient
 
@@ -198,10 +200,10 @@ async def _authenticate_with_oauth(client: synapseclient.Synapse, ctx: Context, 
     """
     try:
         # Authenticate using the access token
-        client.login(authToken=token)
+        await anyio.to_thread.run_sync(lambda: client.login(authToken=token))
 
         # Get user profile to verify authentication
-        profile = client.getUserProfile()
+        profile = await anyio.to_thread.run_sync(client.getUserProfile)
 
         # Store auth info in context
         await _set_state(ctx, USER_AUTH_INFO_KEY, {
@@ -235,10 +237,10 @@ async def _authenticate_with_pat(client: synapseclient.Synapse, ctx: Context, to
     """
     try:
         # Authenticate using PAT
-        client.login(authToken=token, silent=True)
+        await anyio.to_thread.run_sync(lambda: client.login(authToken=token, silent=True))
 
         # Get user profile to verify authentication
-        profile = client.getUserProfile()
+        profile = await anyio.to_thread.run_sync(client.getUserProfile)
 
         # Store auth info in context
         await _set_state(ctx, USER_AUTH_INFO_KEY, {

--- a/src/synapse_mcp/tools.py
+++ b/src/synapse_mcp/tools.py
@@ -1,8 +1,10 @@
 """Tool registrations for Synapse MCP."""
 
 import json
+from functools import partial
 from typing import Any, Dict, List, Optional
 
+import anyio.to_thread
 from fastmcp import Context
 from synapseclient.core.exceptions import SynapseHTTPError
 
@@ -48,7 +50,9 @@ async def get_entity(entity_id: str, ctx: Context) -> Dict[str, Any]:
 
     try:
         entity_ops = await get_entity_operations(ctx)
-        return entity_ops["base"].get_entity_by_id(entity_id)
+        return await anyio.to_thread.run_sync(
+            partial(entity_ops["base"].get_entity_by_id, entity_id)
+        )
     except ConnectionAuthError as exc:
         return {"error": f"Authentication required: {exc}", "entity_id": entity_id}
     except Exception as exc:  # pragma: no cover - defensive path
@@ -72,7 +76,9 @@ async def get_entity_annotations(entity_id: str, ctx: Context) -> Dict[str, Any]
 
     try:
         entity_ops = await get_entity_operations(ctx)
-        annotations = entity_ops["base"].get_entity_annotations(entity_id)
+        annotations = await anyio.to_thread.run_sync(
+            partial(entity_ops["base"].get_entity_annotations, entity_id)
+        )
         return format_annotations(annotations)
     except ConnectionAuthError as exc:
         return {"error": f"Authentication required: {exc}", "entity_id": entity_id}
@@ -114,7 +120,9 @@ async def get_entity_provenance(
             return {"error": f"Invalid version number: {version}", "entity_id": entity_id}
 
     try:
-        activity = synapse_client.getProvenance(entity_id, version=normalized_version)
+        activity = await anyio.to_thread.run_sync(
+            partial(synapse_client.getProvenance, entity_id, version=normalized_version)
+        )
     except SynapseHTTPError as exc:
         response = getattr(exc, "response", None)
         status_code = getattr(response, "status_code", None)
@@ -173,14 +181,17 @@ async def get_entity_children(entity_id: str, ctx: Context) -> List[Dict[str, An
 
     try:
         entity_ops = await get_entity_operations(ctx)
-        entity = entity_ops["base"].get_entity_by_id(entity_id)
-        entity_type = entity.get("type", "").lower()
 
-        if entity_type == "project":
-            return entity_ops["project"].get_project_children(entity_id)
-        if entity_type == "folder":
-            return entity_ops["folder"].get_folder_children(entity_id)
-        return [{"error": f"Entity {entity_id} is not a container entity"}]
+        def _get_children() -> List[Dict[str, Any]]:
+            entity = entity_ops["base"].get_entity_by_id(entity_id)
+            entity_type = entity.get("type", "").lower()
+            if entity_type == "project":
+                return entity_ops["project"].get_project_children(entity_id)
+            if entity_type == "folder":
+                return entity_ops["folder"].get_folder_children(entity_id)
+            return [{"error": f"Entity {entity_id} is not a container entity"}]
+
+        return await anyio.to_thread.run_sync(_get_children)
     except ConnectionAuthError as exc:
         return [{"error": f"Authentication required: {exc}", "entity_id": entity_id}]
     except Exception as exc:  # pragma: no cover - defensive path
@@ -264,7 +275,9 @@ async def search_synapse(
     dropped_return_fields: Optional[List[str]] = None
 
     try:
-        response = synapse_client.restPOST("/search", body=json.dumps(request_payload))
+        response = await anyio.to_thread.run_sync(
+            partial(synapse_client.restPOST, "/search", body=json.dumps(request_payload))
+        )
     except ConnectionAuthError as exc:
         return {"error": f"Authentication required: {exc}"}
     except Exception as exc:  # pragma: no cover - defensive path
@@ -275,7 +288,9 @@ async def search_synapse(
             fallback_payload = {k: v for k, v in request_payload.items() if k != "returnFields"}
 
             try:
-                response = synapse_client.restPOST("/search", body=json.dumps(fallback_payload))
+                response = await anyio.to_thread.run_sync(
+                    partial(synapse_client.restPOST, "/search", body=json.dumps(fallback_payload))
+                )
             except Exception as fallback_exc:  # pragma: no cover - defensive path
                 return {
                     "error": str(fallback_exc),


### PR DESCRIPTION
# **Problem:**

- The fastmcp 3.x upgrade (PR #33) made all tool functions `async def` — necessary because `ctx.get_state()`/`ctx.set_state()` are now coroutines.
- However, fastmcp 3.x executes async tools with a direct `await` on the event loop, whereas sync tools are automatically dispatched to a thread pool via `call_sync_fn_in_threadpool`.
- By becoming `async def`, the tools lost that automatic protection: blocking `synapseclient` network calls (`client.get()`, `client.login()`, `client.getUserProfile()`, `restPOST()`, `getProvenance()`) now run on the event loop and block all concurrent requests for their full duration.

# **Solution:**

Wrap every blocking `synapseclient` call in `anyio.to_thread.run_sync`, which dispatches the call to a worker thread and yields control back to the event loop while waiting.

**`connection_auth.py`**
- `client.login()` and `client.getUserProfile()` in both `_authenticate_with_oauth` and `_authenticate_with_pat`

**`tools.py`**
- `get_entity_by_id` in `get_entity`
- `get_entity_annotations` in `get_entity_annotations`
- `getProvenance` in `get_entity_provenance`
- `get_entity_children` — the lookup + children fetch grouped into a single `_get_children` helper to avoid two thread hops for one logical operation
- `restPOST` (primary and fallback) in `search_synapse`

A fuller migration to `synapseclient.operations.get_async` (the native async API introduced in synapseclient 4.x) would eliminate the need for thread offloading entirely, but that requires replacing the existing `entities/` layer and is tracked as a follow-up.

# **Testing:**

- All 63 tests pass: `SYNAPSE_PAT=test-token .venv/bin/python3 -m pytest --no-cov -q` → `63 passed`
- Unit tests mock the synapseclient calls so they exercise the async wrappers without real I/O


NOTE:
This is untested locally, and... I'm not 100% certain if this _really_ is a concern - there is also probably a better way to do this because synapseclient offers async functionality out of the box, but that requires a greater refactor