### PR TITLE
Fix: Return fastmcp AccessToken from SynapseJWTVerifier instead of SimpleNamespace

### DIFF
--- a/src/synapse_mcp/oauth/jwt.py
+++ b/src/synapse_mcp/oauth/jwt.py
@@ -3,9 +3,9 @@
 import asyncio
 import logging
 from concurrent.futures import ThreadPoolExecutor
-from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 
+from fastmcp.server.auth.auth import AccessToken
 from jwt import PyJWKClient, decode
 from jwt.exceptions import PyJWTError
 
@@ -30,7 +30,7 @@ class SynapseJWTVerifier:
         self.jwks_client = PyJWKClient(uri=jwks_uri)
         self._executor = ThreadPoolExecutor(max_workers=2)
 
-    async def verify_token(self, token: str) -> Optional[SimpleNamespace]:
+    async def verify_token(self, token: str) -> Optional[AccessToken]:
         try:
             loop = asyncio.get_event_loop()
             return await loop.run_in_executor(self._executor, self._verify_token_sync, token)
@@ -38,7 +38,7 @@ class SynapseJWTVerifier:
             logger.error("Error in async Synapse JWT verification: %s", exc)
             return None
 
-    def _verify_token_sync(self, token: str) -> Optional[SimpleNamespace]:
+    def _verify_token_sync(self, token: str) -> Optional[AccessToken]:
         try:
             signing_key = self.jwks_client.get_signing_key_from_jwt(token)
 
@@ -56,10 +56,7 @@ class SynapseJWTVerifier:
                 logger.warning("Required scopes validation failed")
                 return None
 
-            access_token_obj = self._create_fastmcp_access_token(
-                decoded, scopes, token)
-            access_token_obj.raw_token = token
-            return access_token_obj
+            return self._create_fastmcp_access_token(decoded, scopes, token)
 
         except PyJWTError as exc:
             logger.error("JWT verification FAILED: %s (type: %s)",
@@ -93,16 +90,18 @@ class SynapseJWTVerifier:
 
     def _create_fastmcp_access_token(
         self, decoded: Dict[str, Any], scopes: List[str], token: str
-    ) -> SimpleNamespace:
-        access_token = SimpleNamespace()
-        access_token.sub = decoded.get("sub")
-        access_token.client_id = decoded.get("aud")
-        access_token.expires_at = decoded.get("exp", 0)
-        access_token.scopes = scopes
-        access_token.claims = decoded
-        access_token.token = token
+    ) -> AccessToken:
+        aud = decoded.get("aud", "")
+        client_id = aud[0] if isinstance(aud, list) else (aud or "")
+        access_token = AccessToken(
+            token=token,
+            client_id=client_id,
+            scopes=scopes,
+            expires_at=decoded.get("exp"),
+            claims=decoded,
+        )
         logger.debug(
-            "Created FastMCP access token for subject: %s", access_token.sub)
+            "Created FastMCP access token for subject: %s", decoded.get("sub"))
         return access_token
 
     def __del__(self) -> None:  # pragma: no cover - cleanup

--- a/src/synapse_mcp/oauth/jwt.py
+++ b/src/synapse_mcp/oauth/jwt.py
@@ -32,7 +32,7 @@ class SynapseJWTVerifier:
 
     async def verify_token(self, token: str) -> Optional[AccessToken]:
         try:
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             return await loop.run_in_executor(self._executor, self._verify_token_sync, token)
         except Exception as exc:  # pragma: no cover - defensive
             logger.error("Error in async Synapse JWT verification: %s", exc)
@@ -92,7 +92,10 @@ class SynapseJWTVerifier:
         self, decoded: Dict[str, Any], scopes: List[str], token: str
     ) -> AccessToken:
         aud = decoded.get("aud", "")
-        client_id = aud[0] if isinstance(aud, list) else (aud or "")
+        if isinstance(aud, list):
+            client_id = aud[0] if aud else ""
+        else:
+            client_id = aud or ""
         access_token = AccessToken(
             token=token,
             client_id=client_id,

--- a/src/synapse_mcp/oauth/jwt.py
+++ b/src/synapse_mcp/oauth/jwt.py
@@ -91,11 +91,7 @@ class SynapseJWTVerifier:
     def _create_fastmcp_access_token(
         self, decoded: Dict[str, Any], scopes: List[str], token: str
     ) -> AccessToken:
-        aud = decoded.get("aud", "")
-        if isinstance(aud, list):
-            client_id = aud[0] if aud else ""
-        else:
-            client_id = aud or ""
+        client_id = self.audience
         access_token = AccessToken(
             token=token,
             client_id=client_id,

--- a/tests/test_oauth_jwt.py
+++ b/tests/test_oauth_jwt.py
@@ -1,9 +1,5 @@
 """Tests for Synapse JWT verifier."""
 
-import asyncio
-
-import pytest
-
 import synapse_mcp.oauth.jwt as jwt_module
 from fastmcp.server.auth.auth import AccessToken
 

--- a/tests/test_oauth_jwt.py
+++ b/tests/test_oauth_jwt.py
@@ -1,11 +1,11 @@
 """Tests for Synapse JWT verifier."""
 
 import asyncio
-from types import SimpleNamespace
 
 import pytest
 
 import synapse_mcp.oauth.jwt as jwt_module
+from fastmcp.server.auth.auth import AccessToken
 
 
 def _setup_jwt_mocks(monkeypatch, decoded_payload):
@@ -36,9 +36,12 @@ def test_verify_token_success(monkeypatch):
         required_scopes=["openid", "view"],
     )
 
-    result: SimpleNamespace = verifier._verify_token_sync("token")  # type: ignore[attr-defined]
-    assert result.sub == "user"
+    result: AccessToken = verifier._verify_token_sync("token")  # type: ignore[attr-defined]
+    assert isinstance(result, AccessToken)
+    assert result.claims.get("sub") == "user"
     assert result.scopes == ["openid", "view"]
+    assert result.token == "token"
+    assert result.client_id == "client"
 
 
 def test_verify_token_missing_scope_returns_none(monkeypatch):

--- a/tests/test_oauth_jwt.py
+++ b/tests/test_oauth_jwt.py
@@ -40,47 +40,6 @@ def test_verify_token_success(monkeypatch):
     assert result.client_id == "client"
 
 
-def test_verify_token_aud_as_list(monkeypatch):
-    decoded = {
-        "sub": "user",
-        "aud": ["client", "other"],
-        "exp": 123,
-        "access": {"scope": ["openid", "view"]},
-    }
-    _setup_jwt_mocks(monkeypatch, decoded)
-
-    verifier = jwt_module.SynapseJWTVerifier(
-        jwks_uri="http://example/jwks",
-        issuer="issuer",
-        audience="client",
-        required_scopes=["openid", "view"],
-    )
-
-    result: AccessToken = verifier._verify_token_sync("token")  # type: ignore[attr-defined]
-    assert isinstance(result, AccessToken)
-    assert result.client_id == "client"
-
-
-def test_verify_token_aud_as_empty_list(monkeypatch):
-    decoded = {
-        "sub": "user",
-        "aud": [],
-        "exp": 123,
-        "access": {"scope": ["openid", "view"]},
-    }
-    _setup_jwt_mocks(monkeypatch, decoded)
-
-    verifier = jwt_module.SynapseJWTVerifier(
-        jwks_uri="http://example/jwks",
-        issuer="issuer",
-        audience="client",
-        required_scopes=["openid", "view"],
-    )
-
-    result: AccessToken = verifier._verify_token_sync("token")  # type: ignore[attr-defined]
-    assert isinstance(result, AccessToken)
-    assert result.client_id == ""
-
 
 def test_verify_token_missing_scope_returns_none(monkeypatch):
     decoded = {

--- a/tests/test_oauth_jwt.py
+++ b/tests/test_oauth_jwt.py
@@ -44,6 +44,48 @@ def test_verify_token_success(monkeypatch):
     assert result.client_id == "client"
 
 
+def test_verify_token_aud_as_list(monkeypatch):
+    decoded = {
+        "sub": "user",
+        "aud": ["client", "other"],
+        "exp": 123,
+        "access": {"scope": ["openid", "view"]},
+    }
+    _setup_jwt_mocks(monkeypatch, decoded)
+
+    verifier = jwt_module.SynapseJWTVerifier(
+        jwks_uri="http://example/jwks",
+        issuer="issuer",
+        audience="client",
+        required_scopes=["openid", "view"],
+    )
+
+    result: AccessToken = verifier._verify_token_sync("token")  # type: ignore[attr-defined]
+    assert isinstance(result, AccessToken)
+    assert result.client_id == "client"
+
+
+def test_verify_token_aud_as_empty_list(monkeypatch):
+    decoded = {
+        "sub": "user",
+        "aud": [],
+        "exp": 123,
+        "access": {"scope": ["openid", "view"]},
+    }
+    _setup_jwt_mocks(monkeypatch, decoded)
+
+    verifier = jwt_module.SynapseJWTVerifier(
+        jwks_uri="http://example/jwks",
+        issuer="issuer",
+        audience="client",
+        required_scopes=["openid", "view"],
+    )
+
+    result: AccessToken = verifier._verify_token_sync("token")  # type: ignore[attr-defined]
+    assert isinstance(result, AccessToken)
+    assert result.client_id == ""
+
+
 def test_verify_token_missing_scope_returns_none(monkeypatch):
     decoded = {
         "sub": "user",


### PR DESCRIPTION
# **Problem:**

- FastMCP 3.2.3 added a strict `isinstance` type check on the return value of `verify_access_token`. The check requires a `fastmcp.server.auth.auth.AccessToken` (a Pydantic model) — not a duck-typed object.
- `SynapseJWTVerifier._create_fastmcp_access_token()` was returning a `SimpleNamespace`, causing every MCP request (`ListTools`, `ListResources`, etc.) to fail with: `Expected fastmcp.server.auth.auth.AccessToken, got SimpleNamespace. Ensure the SDK is using the correct AccessToken type.`
- This only manifested in deployed (staging/prod) environments that use the full OAuth proxy flow. Local dev uses `SYNAPSE_PAT` which bypasses `SynapseJWTVerifier` entirely via `PATAuthMiddleware`, so the failure was not visible locally.
- Reproduced by inspecting ECS CloudWatch logs for `synapse-mcp-stage` after enabling `LOG_LEVEL=DEBUG`.

# **Solution:**

- Replaced the `SimpleNamespace` return type in `SynapseJWTVerifier._create_fastmcp_access_token()` with a proper `fastmcp.server.auth.auth.AccessToken` Pydantic model instance.
- Mapped Synapse JWT claims to the correct `AccessToken` fields: `token` (raw upstream JWT), `client_id` (from `self.audience`), `scopes`, `expires_at`, and `claims` (full decoded dict).
- Removed the now-unnecessary `raw_token` attribute assignment — `auth_middleware.py` already falls back from `.raw_token` to `.token`, which is the correct field on the Pydantic model.
- No changes to the OAuth flow or token validation logic.

# **Testing:**

- Updated `tests/test_oauth_jwt.py` to assert the return type is `fastmcp.server.auth.auth.AccessToken` and verify all fields (`token`, `client_id`, `scopes`, `claims`) are populated correctly.
- All 63 tests pass (`uv run pytest tests/`).
- Confirmed fix resolves the `SimpleNamespace` error by inspecting staging ECS CloudWatch logs before and after enabling `LOG_LEVEL=DEBUG`.
- Tested local deployment (even though local deployment doesn't hit this flow)