### PR TITLE
[DPE-1742] Change server setting to run stateless

### DIFF
--- a/src/synapse_mcp/__main__.py
+++ b/src/synapse_mcp/__main__.py
@@ -91,6 +91,7 @@ def main():
                 host=host,
                 port=port,
                 middleware=[grant_types_middleware],
+                stateless_http=True,
             )
         else:
             mcp.run(transport=transport)


### PR DESCRIPTION
# **Problem:**

When the Synapse MCP server runs behind multiple backend instances without session affinity (as in the `mcp.synapse.org` deployment), the standard MCP handshake fails most of the time (reported at 80–95%):

- `initialize` succeeds (HTTP 200) and returns an `Mcp-Session-Id`.
- The immediately-following `notifications/initialized` POST carrying that same session id returns `404 {"code":-32600,"message":"Session not found"}`.

**Root cause:** the server runs FastMCP's Streamable-HTTP transport in stateful mode, where the `Mcp-Session-Id -> ServerSession` map is process-local. With multiple instances and no shared session store or session affinity, the second request load-balances to a different instance that never saw the session, so it returns 404. The affected code is the HTTP `mcp.run(...)` call in `src/synapse_mcp/__main__.py`.

Reported in DPE-1742.

**Reproduced locally** by running two instances of the server (ports 9001/9002) with no shared session store, simulating the multi-replica deploy:

- `initialize` -> instance A: HTTP 200, returns a session id.
- `notifications/initialized` with that id -> instance B (different instance): HTTP 404 "Session not found" — the exact reported error.
- Same request -> instance A (same instance): HTTP 202.
- 20 handshakes with each request routed to a random instance: 9/20 (45%) failed.

# **Solution:**

Set `stateless_http=True` on the HTTP run path in `src/synapse_mcp/__main__.py`. In stateless mode no `Mcp-Session-Id` is minted and every request is fully self-contained, so it no longer matters which instance handles a given request.

**Why this option:** of the candidate fixes (stateless mode, load-balancer sticky sessions, a shared session store, or a single replica), stateless mode is the best fit for this server because it is read-only and request/response with no server-initiated messaging. The server already re-authenticates and rebuilds its Synapse client on every request (the client is stored request-scoped) and holds no meaningful cross-request session state, so stateless mode is not a behavioral regression. It fixes the bug with no infrastructure changes and preserves clean horizontal scaling.

**Impact / trade-offs:** stateless mode forecloses server-initiated features (progress notifications, sampling, resource subscriptions, server push) and session resumability. None of these are used today; enabling them later would require a shared session store. A detailed pros/cons comparison of all four options is recorded on DPE-1742.

# **Testing:**

Validated with a local two-instance harness (PAT mode, dummy token, ports 9001/9002), driving the MCP handshake with curl and controlling which instance each request hits. Same harness run before and after the change:

- Before (`stateless_http` unset): cross-instance `notifications/initialized` returned HTTP 404 "Session not found"; 9/20 (45%) of randomly-routed handshakes failed.
- After (`stateless_http=True`): `initialize` returns 200 with no session id; cross-instance `notifications/initialized` returns HTTP 202; 0/20 randomly-routed handshakes failed.

These were manual transport-level tests, not the pytest suite; no automated test was added. The existing test suite should still be run in CI.
