### PR TITLE
Generate README tool table from the tool catalog

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: sync-readme-tools
+        name: Sync README tool table
+        entry: python scripts/gen_tool_table.py --write
+        language: system
+        files: ^(src/synapse_mcp/tools\.py|scripts/gen_tool_table\.py|README\.md)$
+        pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     hooks:
       - id: sync-readme-tools
         name: Sync README tool table
-        entry: python scripts/gen_tool_table.py --write
+        entry: python3 scripts/gen_tool_table.py --write
         language: system
         files: ^(src/synapse_mcp/tools\.py|scripts/gen_tool_table\.py|README\.md)$
         pass_filenames: false

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -19,6 +19,17 @@ pip install --upgrade -e .
 
 If you have previously installed the package, it is important to use the `--upgrade` flag to ensure the console script is properly generated.
 
+### Pre-commit hooks
+
+Install the pre-commit hooks once after setup so the README tool table stays in sync with the code:
+
+```bash
+pip install pre-commit  # included in requirements-dev.txt
+pre-commit install
+```
+
+The `sync-readme-tools` hook regenerates the Available Tools table in `README.md` from the registered MCP tools whenever `src/synapse_mcp/tools.py`, the generator script, or `README.md` changes. If it rewrites the table during a commit, re-stage `README.md` and commit again. You can also run it manually: `uv run python scripts/gen_tool_table.py`.
+
 ## 2. Run the Server
 
 ### Environment Configuration

--- a/README.md
+++ b/README.md
@@ -5,21 +5,74 @@
 A Model Context Protocol (MCP) server that enables AI agent access to Synapse entities (Datasets, Projects, Folders, Files, Tables, and more).
 
 You (your AI agent) can:
-- Retrieve entities by ID
-- Get entity annotations
-- List entity children
-- Search Synapse entities with path and type filters
-- Inspect provenance/activity recorded for an entity version
+- Retrieve entity metadata, annotations, and children, and search across all entity types
+- Inspect provenance/lineage for an entity version
+- Audit access control (ACLs and your own permissions) across a project subtree
+- Read wikis — pages, table of contents, and revision history
+- Look up teams (members, invitations, membership status) and user profiles
+- Explore challenges: evaluation queues, submissions, and scoring statuses
+- Browse JSON schemas and their validation results, plus schema organizations
+- List curation tasks and their linked resources, and read form submissions
+- Resolve entities by exact name or MD5 hash and validate Synapse IDs
 
 ## Available Tools
 
-| Tool | Friendly Name | Description |
+All tools are **read-only** (no create/update/delete) — the server surfaces Synapse metadata, never mutates it and never downloads file content.
+
+<!-- BEGIN GENERATED TOOLS: run `uv run python scripts/gen_tool_table.py` to update -->
+
+| Tool | Domain | Description |
 | --- | --- | --- |
-| `get_entity(entity_id)` | Fetch Entity | Fetch core metadata for a Synapse entity by ID. |
-| `get_entity_annotations(entity_id)` | Fetch Entity Annotations | Return custom annotations associated with an entity. |
-| `get_entity_provenance(entity_id, version=None)` | Fetch Entity Provenance | Retrieve provenance (activity) metadata for an entity, optionally scoped to a specific version. |
-| `get_entity_children(entity_id)` | List Entity Children | List children for container entities such as projects and folders. |
-| `search_synapse(query_term=None, ...)` | Search Synapse | Search Synapse entities by keyword with optional name/type/parent filters. Results are provided by Synapse as data custodian; attribution and licensing follow the source entity metadata. |
+| `get_entity(entity_id)` | entity | Use this when the user wants the metadata, record, details, or info for a specific Synapse entity given its Synapse ID. |
+| `get_entity_acl(entity_id)` | entity | Use this when the user wants the sharing settings or access control list (ACL) of one single Synapse entity — who can access it and with what permissions. |
+| `get_entity_annotations(entity_id)` | entity | Use this when the user wants the custom annotations (metadata key/value pairs) attached to a Synapse entity. |
+| `get_entity_children(entity_id)` | entity | Use this when the user wants to list the files and sub-folders immediately inside a Synapse entity container (one level deep). |
+| `get_entity_permissions(entity_id)` | entity | Use this when the user wants to know what the currently authenticated user is allowed to do on a Synapse entity (READ, UPDATE, DELETE, etc.). |
+| `get_link(entity_id)` | entity | Use this when the user has a Synapse Link entity (a shortcut that points at another entity) and wants either the Link's own metadata or the target it resolves to. |
+| `list_entity_acl(entity_id)` | entity | Use this when the user wants every ACL on a Synapse entity and, with recursive=True, on all its descendants — useful for auditing sharing recursively across a project subtree. |
+| `search_synapse()` | search | Use this when the user wants to search for Synapse entities matching a keyword, topic, or subject (e.g. 'brain tissue', 'cancer_type=glioma'). |
+| `get_entity_provenance()` | activity | Use this when the user wants to know what produced a Synapse entity — its data lineage, inputs, outputs, code executed, and the activity that generated it. |
+| `get_entity_schema(entity_id)` | schema | Use this when the user wants to know which JSON schema (data model / validation contract) is bound to a Synapse entity. |
+| `get_entity_schema_derived_keys(entity_id)` | schema | Use this when the user wants the annotation keys a bound JSON schema requires on a Synapse entity. |
+| `get_entity_schema_invalid_validations(entity_id)` | schema | Use this when the user wants the list of Synapse entities inside a Folder or Project that currently fail their bound JSON schema — the 'what's broken' view. |
+| `get_entity_schema_validation_statistics(entity_id)` | schema | Use this when the user wants an aggregate validation summary for a Synapse entity container (Folder or Project) with a bound JSON schema — how many child entities pass or fail validation. |
+| `get_json_schema(organization_name, schema_name)` | schema | Use this when the user wants metadata about a specific Synapse JSON Schema (data model, validation contract). |
+| `get_json_schema_body(organization_name, schema_name)` | schema | Use this when the user wants the raw JSON document of a Synapse JSON Schema — the actual data model / validation rules. |
+| `list_json_schema_versions(organization_name, schema_name)` | schema | Use this when the user wants every version published for a Synapse JSON Schema. |
+| `list_json_schemas(organization_name)` | schema | Use this when the user wants every Synapse JSON Schema (data model, validation contract) owned by an organization. |
+| `get_wiki_headers(owner_id)` | wiki | Use this when the user wants the table of contents of a Synapse wiki — the list of pages and sub-pages attached to an entity. |
+| `get_wiki_history(owner_id, wiki_id)` | wiki | Use this when the user wants the revision history (edit log) of a specific Synapse wiki page — who changed it and when. |
+| `get_wiki_order_hint(owner_id)` | wiki | Use this when the user wants to know the display order of sub-pages in a Synapse wiki — how the wiki navigation is sorted. |
+| `get_wiki_page(owner_id)` | wiki | Use this when the user wants to read a Synapse wiki page — its markdown content and metadata — attached to a project, folder, or file. |
+| `get_team()` | team | Use this when the user wants a Synapse team by its numeric ID or name. |
+| `get_team_members(team_id)` | team | Use this when the user wants the roster of a Synapse team — who is on it. |
+| `get_team_membership_status(team_id, user_id)` | team | Use this when the user wants to know whether a specific Synapse user is already a member of, has applied to, or has been invited to a Synapse team. |
+| `get_team_open_invitations(team_id)` | team | Use this when the user wants the pending (not yet accepted or rejected) invitations for a Synapse team. |
+| `check_user_certified(user_id)` | user | Use this when the user wants to know whether a Synapse user has passed the certification quiz required for uploading human data. |
+| `get_user_profile()` | user | Use this when the user wants a Synapse user profile by numeric user ID or username, or the authenticated caller's own profile when called with no arguments. |
+| `get_evaluation()` | evaluation | Use this when the user wants a Synapse Evaluation queue — the challenge/competition queue that participants submit models or results to. |
+| `get_evaluation_acl(evaluation_id)` | evaluation | Use this when the user wants the resource-level access control list of a Synapse Evaluation queue (challenge queue) — which principals (users and teams) hold which access types on the queue. |
+| `get_evaluation_permissions(evaluation_id)` | evaluation | Use this when the user wants to know what the authenticated caller is allowed to do on a Synapse Evaluation queue (challenge queue) — submit, administer, etc. Returns the caller's own effective permission flags. |
+| `list_evaluations()` | evaluation | Use this when the user wants to enumerate Synapse Evaluation queues (challenges, competitions, leaderboards) — optionally filtered by project, access type, or active-only. |
+| `get_submission(submission_id)` | submission | Use this when the user wants a specific Synapse submission — a challenge entry a participant sent to an Evaluation queue. |
+| `get_submission_count(evaluation_id)` | submission | Use this when the user wants only the count of Synapse submissions (challenge entries) in an Evaluation queue, not the submissions themselves. |
+| `get_submission_status(submission_id)` | submission | Use this when the user wants the scoring status of a single Synapse submission (challenge entry) — e.g. RECEIVED, EVALUATION_IN_PROGRESS, SCORED. |
+| `list_evaluation_submission_bundles(evaluation_id)` | submission | Use this when the user wants Synapse submission plus scoring status together (as bundles) for an Evaluation queue — one call returns both sides. |
+| `list_evaluation_submissions(evaluation_id)` | submission | Use this when the user wants ALL submissions (every challenge entry from every participant) sent to a Synapse Evaluation queue — optionally filtered by status (SCORED, INVALID, etc.). |
+| `list_my_submission_bundles(evaluation_id)` | submission | Use this when the user wants their own Synapse submission+status bundles for an Evaluation queue — one call returns both submission and scoring status for every entry they made. |
+| `list_my_submissions(evaluation_id)` | submission | Use this when the user wants their own submissions (challenge entries) to a Synapse Evaluation queue. |
+| `list_submission_statuses(evaluation_id)` | submission | Use this when the user wants the scoring statuses of every Synapse submission in an Evaluation queue — optionally filtered (SCORED, INVALID, etc.). |
+| `get_curation_task(task_id)` | curation | Use this when the user wants the details of a single Synapse curation task by its numeric task ID. |
+| `get_curation_task_resources(task_id)` | curation | Use this when the user wants the Synapse resources (RecordSets, Folders, EntityViews) linked to a curation task — the data the curator will act on. |
+| `list_curation_tasks(project_id)` | curation | Use this when the user wants every Synapse curation task in a project — the queue of data-curation work items attached to that project. |
+| `get_schema_organization(organization_name)` | organization | Use this when the user wants a Synapse JSON Schema Organization (namespace that owns a set of JSON schemas / data models) by name or numeric ID. |
+| `get_schema_organization_acl(organization_name)` | organization | Use this when the user wants the ACL of a Synapse JSON Schema Organization — who may publish schemas under that namespace. |
+| `list_form_data(group_id)` | form | Use this when the user wants the form submissions for a Synapse FormGroup — a collection of structured-data forms submitted by users. |
+| `check_synapse_id(syn_id)` | utility | Use this when the user has a string that looks like a Synapse ID (e.g. syn123456) and wants to check whether it exists in Synapse — verifies validity by querying the Synapse backend. |
+| `search_entities_by_md5(md5)` | utility | Use this when the user has an MD5 hash of a file and wants the Synapse entities (file entities) whose attached file has that exact MD5 — useful for deduplication and 'is this already in Synapse' checks. |
+| `search_entity_by_name(name)` | utility | Use this when the user has a file name or Synapse entity name (and optionally its parent folder or project) but does not know the Synapse ID — resolves an exact name to its Synapse ID. |
+
+<!-- END GENERATED TOOLS -->
 
 ## Available Resources
 
@@ -254,7 +307,7 @@ For contributor/development setup details, see [DEVELOPMENT.md](./DEVELOPMENT.md
 
 #### Tool Discovery
 
-The server replaces the standard `list_tools` with a BM25-ranked `search_tools` synthetic tool so the LLM can find the right tool from a natural-language query without loading the full 50-tool catalog into context on every call. `get_entity` and `search_synapse` remain always-visible. See [doc/tool-authoring.md](./doc/tool-authoring.md) for the conventions each tool follows.
+To keep the LLM's context small, the server does not expose the full tool catalog on every call. The default view is just two always-visible tools — `get_entity` and `search_synapse` — plus a synthetic `search_tools` / `call_tool` pair. To reach any other tool, the LLM issues a natural-language query to `search_tools` (a BM25-ranked search over tool names, descriptions, synonyms, and siblings) and then invokes the chosen tool via `call_tool`. See [doc/tool-authoring.md](./doc/tool-authoring.md) for the conventions each tool follows.
 
 ### Example Prompts
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,4 +53,5 @@ build-backend = "hatchling.build"
 [dependency-groups]
 dev = [
     "pytest>=9.0.3",
+    "pre-commit>=3.0.0",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ flake8>=6.0.0
 fastapi[test]>=0.110.0
 build>=1.0.0
 twine>=4.0.0
+pre-commit>=3.0.0

--- a/scripts/gen_tool_table.py
+++ b/scripts/gen_tool_table.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Generate the Available Tools table in README.md from the live catalog.
+
+Introspects the registered FastMCP tools (the same pre-transform catalog the
+BM25 eval consumes) and renders a Markdown table that is injected into
+README.md between the BEGIN/END markers. Keeping the table generated means it
+never drifts from ``src/synapse_mcp/tools.py``.
+
+Usage:
+    uv run python scripts/gen_tool_table.py            # rewrite README.md
+    uv run python scripts/gen_tool_table.py --write     # same as default
+    uv run python scripts/gen_tool_table.py --check      # verify, never write
+
+``--write`` exits non-zero if it changed the file (pre-commit convention).
+``--check`` exits non-zero if the table is stale, printing a unified diff.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import difflib
+import os
+import sys
+from pathlib import Path
+from typing import Iterable
+
+# app.py raises at import time without auth configured; set a dummy PAT before
+# importing synapse_mcp (same trick as tests/conftest.py).
+os.environ.setdefault("SYNAPSE_PAT", "readme-gen")
+
+from synapse_mcp import mcp  # noqa: E402
+from synapse_mcp.services.tool_service import ServiceName  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README_PATH = REPO_ROOT / "README.md"
+
+BEGIN_MARKER = (
+    "<!-- BEGIN GENERATED TOOLS: run "
+    "`uv run python scripts/gen_tool_table.py` to update -->"
+)
+END_MARKER = "<!-- END GENERATED TOOLS -->"
+
+# Curated domain order, mirroring the "Domain N" sections in tools.py so the
+# README and source tell the same story. Tools with a domain not listed here
+# are appended alphabetically after a warning (never silently dropped).
+DOMAIN_ORDER = [
+    "entity",
+    "search",
+    "activity",
+    "schema",
+    "wiki",
+    "team",
+    "user",
+    "evaluation",
+    "submission",
+    "curation",
+    "organization",
+    "form",
+    "utility",
+]
+
+# Service-name tags, used to pick the domain tag out of the full tag set
+# (which also carries alias tags like "read"/"readonly").
+_SERVICE_TAGS = set(ServiceName.__args__)
+
+
+def _domain_for(tool) -> str:
+    """Return the single service-domain tag for a tool."""
+    domains = sorted(set(tool.tags) & _SERVICE_TAGS)
+    if not domains:
+        return "?"
+    return domains[0]
+
+
+def _signature(tool) -> str:
+    """Render ``name(required_param, ...)`` from the tool's parameter schema.
+
+    ``ctx`` is already excluded by FastMCP. Only required params are shown;
+    tools whose args are all optional render as ``name()``.
+    """
+    params = getattr(tool, "parameters", None) or {}
+    required = params.get("required", []) or []
+    return f"{tool.name}({', '.join(required)})"
+
+
+# Abbreviations whose trailing period is not a sentence end. Compared
+# case-insensitively against the word immediately before a candidate period.
+_ABBREVIATIONS = {"e.g", "i.e", "etc", "vs", "cf", "al", "no", "st"}
+
+
+def _first_sentence(description: str) -> str:
+    """First sentence of the core description.
+
+    The @service_tool decorator appends ``Related terms:`` / ``Distinct from:``
+    sections separated by a blank line; split those off first, then take the
+    first sentence (which the decorator guarantees names the object + intent).
+    Periods inside common abbreviations (e.g., i.e.) are not treated as
+    sentence ends.
+    """
+    core = description.split("\n\n", 1)[0].strip()
+    for i, ch in enumerate(core):
+        if ch != "." or i + 1 >= len(core) or core[i + 1] not in " \n\t":
+            continue
+        # Word preceding this period; skip if it's a known abbreviation
+        # or a single letter (e.g. "A. Smith"). "e.g" matches after the
+        # leading "e." is stripped, so compare the final dotted segment too.
+        word = core[:i].rsplit(" ", 1)[-1].lower().lstrip("([")
+        dotted = word.rsplit(".", 1)[-1] if "." in word else word
+        if word in _ABBREVIATIONS or dotted in _ABBREVIATIONS or len(word) == 1:
+            continue
+        return core[: i + 1].strip()
+    return core
+
+
+def _escape_cell(text: str) -> str:
+    """Escape characters that would break a Markdown table cell."""
+    return text.replace("|", "\\|")
+
+
+def _sort_key(tool):
+    domain = _domain_for(tool)
+    try:
+        domain_rank = DOMAIN_ORDER.index(domain)
+    except ValueError:
+        # Unknown domain: sort after all known ones, alphabetically.
+        domain_rank = len(DOMAIN_ORDER)
+    return (domain_rank, domain, tool.name)
+
+
+def build_table(tools: Iterable) -> str:
+    """Build the Markdown tool table from a catalog of FastMCP tools."""
+    tools = sorted(tools, key=_sort_key)
+
+    unknown = sorted(
+        {_domain_for(t) for t in tools} - set(DOMAIN_ORDER) - {"?"}
+    )
+    if unknown:
+        print(
+            f"WARNING: tools have domains not in DOMAIN_ORDER: {unknown}. "
+            "Add them to scripts/gen_tool_table.py to control ordering.",
+            file=sys.stderr,
+        )
+
+    lines = [
+        "| Tool | Domain | Description |",
+        "| --- | --- | --- |",
+    ]
+    for tool in tools:
+        signature = _escape_cell(_signature(tool))
+        domain = _escape_cell(_domain_for(tool))
+        description = _escape_cell(_first_sentence(tool.description))
+        lines.append(f"| `{signature}` | {domain} | {description} |")
+    return "\n".join(lines)
+
+
+async def _load_tools():
+    # _list_tools() returns the raw pre-transform catalog (all tools).
+    # list_tools() would return only the post-transform always-visible +
+    # synthetic search tools. See tests/evals/test_tool_selection.py.
+    return await mcp._list_tools()
+
+
+def _render_block(table: str) -> str:
+    """Wrap the table in the BEGIN/END markers."""
+    return f"{BEGIN_MARKER}\n\n{table}\n\n{END_MARKER}"
+
+
+def _replace_block(readme_text: str, new_block: str) -> str:
+    """Return README text with the marked block replaced by new_block."""
+    start = readme_text.find(BEGIN_MARKER)
+    end = readme_text.find(END_MARKER)
+    if start == -1 or end == -1 or end < start:
+        raise SystemExit(
+            "Could not find the BEGIN/END GENERATED TOOLS markers in "
+            f"{README_PATH}. Add them where the table should live."
+        )
+    end += len(END_MARKER)
+    return readme_text[:start] + new_block + readme_text[end:]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--write",
+        action="store_true",
+        help="Rewrite the table in README.md (default).",
+    )
+    mode.add_argument(
+        "--check",
+        action="store_true",
+        help="Verify README.md is in sync; never write. Non-zero if stale.",
+    )
+    args = parser.parse_args()
+
+    tools = asyncio.run(_load_tools())
+    new_block = _render_block(build_table(tools))
+
+    readme_text = README_PATH.read_text()
+    updated_text = _replace_block(readme_text, new_block)
+
+    if args.check:
+        if updated_text != readme_text:
+            print(
+                "README.md tool table is out of sync. Run:\n"
+                "    uv run python scripts/gen_tool_table.py\n",
+                file=sys.stderr,
+            )
+            diff = difflib.unified_diff(
+                readme_text.splitlines(keepends=True),
+                updated_text.splitlines(keepends=True),
+                fromfile="README.md (current)",
+                tofile="README.md (expected)",
+            )
+            sys.stderr.writelines(diff)
+            return 1
+        return 0
+
+    # --write (default)
+    if updated_text != readme_text:
+        README_PATH.write_text(updated_text)
+        print(f"Updated tool table in {README_PATH}")
+        return 1
+    print("README.md tool table already up to date.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/gen_tool_table.py
+++ b/scripts/gen_tool_table.py
@@ -15,8 +15,6 @@ Usage:
 ``--check`` exits non-zero if the table is stale, printing a unified diff.
 """
 
-from __future__ import annotations
-
 import argparse
 import asyncio
 import difflib

--- a/scripts/gen_tool_table.py
+++ b/scripts/gen_tool_table.py
@@ -169,8 +169,8 @@ def _render_block(table: str) -> str:
 def _replace_block(readme_text: str, new_block: str) -> str:
     """Return README text with the marked block replaced by new_block."""
     start = readme_text.find(BEGIN_MARKER)
-    end = readme_text.find(END_MARKER)
-    if start == -1 or end == -1 or end < start:
+    end = readme_text.find(END_MARKER, start) if start != -1 else -1
+    if start == -1 or end == -1:
         raise SystemExit(
             "Could not find the BEGIN/END GENERATED TOOLS markers in "
             f"{README_PATH}. Add them where the table should live."

--- a/scripts/gen_tool_table.py
+++ b/scripts/gen_tool_table.py
@@ -29,6 +29,7 @@ from typing import Iterable
 # importing synapse_mcp (same trick as tests/conftest.py).
 os.environ.setdefault("SYNAPSE_PAT", "readme-gen")
 
+from fastmcp.tools import Tool  # noqa: E402  (base class, not FunctionTool)
 from synapse_mcp import mcp  # noqa: E402
 from synapse_mcp.services.tool_service import ServiceName  # noqa: E402
 
@@ -65,7 +66,7 @@ DOMAIN_ORDER = [
 _SERVICE_TAGS = set(ServiceName.__args__)
 
 
-def _domain_for(tool) -> str:
+def _domain_for(tool: Tool) -> str:
     """Return the single service-domain tag for a tool."""
     domains = sorted(set(tool.tags) & _SERVICE_TAGS)
     if not domains:
@@ -73,7 +74,7 @@ def _domain_for(tool) -> str:
     return domains[0]
 
 
-def _signature(tool) -> str:
+def _signature(tool: Tool) -> str:
     """Render ``name(required_param, ...)`` from the tool's parameter schema.
 
     ``ctx`` is already excluded by FastMCP. Only required params are shown;
@@ -118,8 +119,7 @@ def _escape_cell(text: str) -> str:
     return text.replace("|", "\\|")
 
 
-def _sort_key(tool):
-    domain = _domain_for(tool)
+def _sort_key(tool: Tool, domain: str):
     try:
         domain_rank = DOMAIN_ORDER.index(domain)
     except ValueError:
@@ -128,13 +128,13 @@ def _sort_key(tool):
     return (domain_rank, domain, tool.name)
 
 
-def build_table(tools: Iterable) -> str:
+def build_table(tools: Iterable[Tool]) -> str:
     """Build the Markdown tool table from a catalog of FastMCP tools."""
-    tools = sorted(tools, key=_sort_key)
+    # Resolve each tool's domain once; every downstream step reuses it.
+    pairs = [(tool, _domain_for(tool)) for tool in tools]
+    pairs.sort(key=lambda pair: _sort_key(*pair))
 
-    unknown = sorted(
-        {_domain_for(t) for t in tools} - set(DOMAIN_ORDER) - {"?"}
-    )
+    unknown = sorted({d for _, d in pairs} - set(DOMAIN_ORDER) - {"?"})
     if unknown:
         print(
             f"WARNING: tools have domains not in DOMAIN_ORDER: {unknown}. "
@@ -146,11 +146,11 @@ def build_table(tools: Iterable) -> str:
         "| Tool | Domain | Description |",
         "| --- | --- | --- |",
     ]
-    for tool in tools:
+    for tool, domain in pairs:
         signature = _escape_cell(_signature(tool))
-        domain = _escape_cell(_domain_for(tool))
+        domain_cell = _escape_cell(domain)
         description = _escape_cell(_first_sentence(tool.description))
-        lines.append(f"| `{signature}` | {domain} | {description} |")
+        lines.append(f"| `{signature}` | {domain_cell} | {description} |")
     return "\n".join(lines)
 
 

--- a/tests/test_readme_tools.py
+++ b/tests/test_readme_tools.py
@@ -1,0 +1,29 @@
+"""Guard that README.md's tool table stays in sync with the code.
+
+Shells out to ``scripts/gen_tool_table.py --check`` so CI fails (with a diff)
+whenever a tool is added, renamed, or re-described without regenerating the
+README table. Run ``uv run python scripts/gen_tool_table.py`` to fix.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "gen_tool_table.py"
+
+
+def test_readme_tool_table_in_sync():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--check"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "SYNAPSE_PAT": "dummy-for-tests"},
+    )
+    assert result.returncode == 0, (
+        "README.md tool table is out of sync with the tool catalog.\n"
+        "Run: uv run python scripts/gen_tool_table.py\n\n"
+        f"{result.stdout}\n{result.stderr}"
+    )

--- a/tests/test_readme_tools.py
+++ b/tests/test_readme_tools.py
@@ -15,12 +15,18 @@ SCRIPT = REPO_ROOT / "scripts" / "gen_tool_table.py"
 
 
 def test_readme_tool_table_in_sync():
+    # Force PAT auth in the child: strip any OAuth vars the developer env may
+    # carry, otherwise app.py would select OAuth mode and change import
+    # side effects.
+    env = {**os.environ, "SYNAPSE_PAT": "dummy-for-tests"}
+    env.pop("SYNAPSE_OAUTH_CLIENT_ID", None)
+    env.pop("SYNAPSE_OAUTH_CLIENT_SECRET", None)
     result = subprocess.run(
         [sys.executable, str(SCRIPT), "--check"],
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
-        env={**os.environ, "SYNAPSE_PAT": "dummy-for-tests"},
+        env=env,
     )
     assert result.returncode == 0, (
         "README.md tool table is out of sync with the tool catalog.\n"

--- a/uv.lock
+++ b/uv.lock
@@ -242,6 +242,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -410,6 +419,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distlib"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -491,6 +509,15 @@ wheels = [
 ]
 
 [[package]]
+name = "filelock"
+version = "3.29.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/c8/35bdf04fb30755e2ed758f877edf3eb4a243c2463d3a258cc28b18b7a6e2/filelock-3.29.6.tar.gz", hash = "sha256:895c532ef3f4ef04972b9446a8c4e2931a5c399ff3c4be4c9369f2639b80f793", size = 70301, upload-time = "2026-07-06T23:08:08.577Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/49/7467c2946ccd9617f7da38187071bdc45bb9a95df51f4d63d6622432ce4e/filelock-3.29.6-py3-none-any.whl", hash = "sha256:14d5f5597d2e0c4dbd774cfb6d8132da1db44da83732aab679d54f7dcf97ab65", size = 45478, upload-time = "2026-07-06T23:08:07.197Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.75.0"
 source = { registry = "https://pypi.org/simple" }
@@ -546,6 +573,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4c/60/8f4281fa9bbf3c8034fd54c0e7412e66edbab6bc74c4996bd616f8d0406e/httpx-sse-0.4.0.tar.gz", hash = "sha256:1e81a3a3070ce322add1d3529ed42eb5f70817f45ed6ec915ab753f961139721", size = 12624, upload-time = "2023-12-22T08:01:21.083Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/9b/a181f281f65d776426002f330c31849b86b31fc9d848db62e16f03ff739f/httpx_sse-0.4.0-py3-none-any.whl", hash = "sha256:f329af6eae57eaa2bdfd962b42524764af68075ea87370a2de920af5341e318f", size = 7819, upload-time = "2023-12-22T08:01:19.89Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
 ]
 
 [[package]]
@@ -765,6 +801,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
 ]
 
 [[package]]
@@ -1155,6 +1200,22 @@ wheels = [
 ]
 
 [[package]]
+name = "pre-commit"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1431,6 +1492,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/26/8b004cc36f430345136f6f00fa1aa9ed596c8ed1e8504625fa79522ff39c/python_discovery-1.4.3.tar.gz", hash = "sha256:ad57d7045a862460d4a235986c33f13ed707d3aeb9153fa47eb7dfd0d4673289", size = 70438, upload-time = "2026-07-03T13:21:51.621Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/78/9b77ecb4644d1bbea94d29abf78f21c47eca6eb79e9745b702ec0bed2e19/python_discovery-1.4.3-py3-none-any.whl", hash = "sha256:b6e1e4a7d9e3f6948c39746ffe8218225162d738ba39d05ab1d2f6c1cac4878c", size = 33885, upload-time = "2026-07-03T13:21:50.174Z" },
 ]
 
 [[package]]
@@ -1835,6 +1909,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pre-commit" },
     { name = "pytest" },
 ]
 
@@ -1857,7 +1932,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=9.0.3" }]
+dev = [
+    { name = "pre-commit", specifier = ">=3.0.0" },
+    { name = "pytest", specifier = ">=9.0.3" },
+]
 
 [[package]]
 name = "synapseclient"
@@ -2005,6 +2083,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/da/6eee1ff8b6cbeed47eeb5229749168e81eb4b7b999a1a15a7176e51410c9/uvicorn-0.44.0.tar.gz", hash = "sha256:6c942071b68f07e178264b9152f1f16dfac5da85880c4ce06366a96d70d4f31e", size = 86947, upload-time = "2026-04-06T09:23:22.826Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/23/a5bbd9600dd607411fa644c06ff4951bec3a4d82c4b852374024359c19c0/uvicorn-0.44.0-py3-none-any.whl", hash = "sha256:ce937c99a2cc70279556967274414c087888e8cec9f9c94644dfca11bd3ced89", size = 69425, upload-time = "2026-04-06T09:23:21.524Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/65/ec1d92091671e6407d3e7c1f5801413bb7b2b57630a50cae7750456ba0ed/virtualenv-21.6.0.tar.gz", hash = "sha256:e18a4d750f2b64dea73e72ffde3922f3c52365fabdc8157ebd3da20d031c4734", size = 5526111, upload-time = "2026-07-06T22:49:56.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/e7/2fbd0cc1653c53eed8f10670538bb547de2b3e37aacad283faa82a71094b/virtualenv-21.6.0-py3-none-any.whl", hash = "sha256:bce9d097950fef9d81129b333babfb7767072850c2f1acce0ec536708401bfd1", size = 5506216, upload-time = "2026-07-06T22:49:54.941Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# **Problem:**

The README's **Available Tools** section documented only **5 tools** (`get_entity`, `get_entity_annotations`, `get_entity_provenance`, `get_entity_children`, `search_synapse`), but `src/synapse_mcp/tools.py` now registers **48 read-only tools across 12 service domains** (entity, search, activity, schema, wiki, team, user, evaluation, submission, curation, organization, form, utility). The "You can" capability list and the Tool Discovery paragraph (which said "50-tool catalog") were likewise stale. A hand-maintained table of 48 tools is guaranteed to drift as tools are added or reworded.

# **Solution:**

Make the table **generated from the live catalog** and **kept in sync automatically**, so it can't drift. Only the table is generated; surrounding prose stays hand-written so the doc reads well.

- **`scripts/gen_tool_table.py`** — introspects `mcp._list_tools()` (the pre-transform catalog, the same path the BM25 eval uses) and renders `| Tool | Domain | Description |` between `BEGIN/END GENERATED TOOLS` markers. Tool column shows required params only (`get_entity(entity_id)`, `search_synapse()`); Description is the first sentence (with an abbreviation guard so `e.g.`/`i.e.` don't truncate); rows follow a curated domain order mirroring `tools.py`, alphabetical within a domain. Unknown domains append with a warning (never silently dropped). Modes: `--write` (auto-fix, non-zero if it changed the file) and `--check` (never writes, prints a unified diff on drift).
- **`README.md`** — expanded the capability summary, inserted the generated table, added a "all tools are read-only" note, and rewrote the Tool Discovery paragraph to describe the actual mechanism (always-visible `get_entity`/`search_synapse` + synthetic `search_tools`/`call_tool`).
- **`.pre-commit-config.yaml`** — first pre-commit config in the repo; a `repo: local`, `language: system` `sync-readme-tools` hook that auto-fixes the table when `tools.py`, the script, or `README.md` change.
- **`tests/test_readme_tools.py`** — subprocesses `--check`, so the existing CI `pytest` job fails (with the diff) on drift — no new CI job.
- **Dev deps / docs** — added `pre-commit` to `requirements-dev.txt` and the `pyproject.toml` dev group; documented `pre-commit install` in `DEVELOPMENT.md`.

**Design decisions:** three enforcement layers (script + pre-commit + CI test) so drift is caught before push *and* at merge; pre-commit auto-fixes locally while CI is check-only (must not mutate the tree); the generator's `build_table` logic is shared via the single `--check` path.

Note: `uv.lock` updated because `pre-commit` was added to the dev group. A couple of pre-existing "50 tools" comments in `tests/` were left out of scope — the generated table is now the single source of truth for the count.

# **Testing:**

- `uv run python scripts/gen_tool_table.py` produces a 48-row table matching `grep -c '^async def ' src/synapse_mcp/tools.py`; second run is a no-op (idempotent).
- `--check` exits 0 when in sync; corrupting a row makes it exit 1 and print a unified diff; reverting restores exit 0.
- Pre-commit hook: passes on a clean tree; on a stale README it reports "files were modified" and rewrites the table, then passes on re-run (byte-identical to correct output).
- `uv run pytest tests/test_readme_tools.py` passes; full suite: **307 passed**.