### PR TITLE
Request-scope per-request auth state to prevent cross-user collisions

### DIFF
--- a/src/synapse_mcp/auth_middleware.py
+++ b/src/synapse_mcp/auth_middleware.py
@@ -192,7 +192,7 @@ class OAuthTokenMiddleware(Middleware):
 
         # Store validated token in context for connection_auth to use
         if hasattr(fast_ctx, "set_state"):
-            await fast_ctx.set_state("oauth_access_token", token)
+            await fast_ctx.set_state("oauth_access_token", token, serializable=False)
             logger.debug("Stored validated OAuth token in context")
         else:
             logger.warning(
@@ -393,7 +393,7 @@ class PATAuthMiddleware(Middleware):
             return
 
         if hasattr(fast_ctx, "set_state"):
-            await fast_ctx.set_state("synapse_pat_token", self.synapse_pat)
+            await fast_ctx.set_state("synapse_pat_token", self.synapse_pat, serializable=False)
             logger.debug("Injected PAT token into context")
         else:
             logger.warning(

--- a/src/synapse_mcp/connection_auth.py
+++ b/src/synapse_mcp/connection_auth.py
@@ -1,8 +1,11 @@
 """
-Connection-scoped authentication for production multi-user support.
+Request-scoped authentication for production multi-user support.
 
-This module provides per-connection synapseclient management to ensure
+This module provides per-request synapseclient management to ensure
 user isolation and prevent cross-user data leakage in production deployments.
+The client and auth state are stored request-scoped (serializable=False), so
+they live only for the current MCP request and are never shared across
+requests or placed in the process-global session store.
 
 ## Architecture
 
@@ -104,21 +107,23 @@ class ConnectionAuthError(Exception):
 
 async def get_synapse_client(ctx: Context) -> synapseclient.Synapse:
     """
-    Get or create a synapseclient instance for this connection.
+    Get or create a synapseclient instance for this request.
 
-    This function ensures each connection has its own isolated synapseclient
+    This function ensures each request has its own isolated synapseclient
     instance, preventing cross-user authentication issues and data leakage.
+    The client is cached in request-scoped state, so repeated calls within the
+    same request reuse it, but each new request builds a fresh client.
 
     Args:
-        ctx: FastMCP context object for this connection
+        ctx: FastMCP context object for this request
 
     Returns:
-        synapseclient.Synapse: Authenticated client for this connection
+        synapseclient.Synapse: Authenticated client for this request
 
     Raises:
         ConnectionAuthError: If authentication fails or is not configured
     """
-    # Check if client already exists for this connection
+    # Check if client already exists for this request
     logger.debug("get_synapse_client called with context type=%s attrs=%s", type(
         ctx).__name__, dir(ctx))
     client = await _get_state(ctx, SYNAPSE_CLIENT_KEY)
@@ -137,8 +142,9 @@ async def get_synapse_client(ctx: Context) -> synapseclient.Synapse:
         raise ConnectionAuthError(
             "Authentication for connection needed (or re-authentication for expired sessions).")
 
-    # Store client in connection context (not JSON-serializable)
-    # Store client in request-scoped context (not JSON-serializable)
+    # Store client in request-scoped state (not JSON-serializable, does not
+    # persist across requests)
+    await _set_state(ctx, SYNAPSE_CLIENT_KEY, client, serializable=False)
     await _set_state(ctx, AUTH_INITIALIZED_KEY, True, serializable=False)
 
     logger.info(

--- a/src/synapse_mcp/connection_auth.py
+++ b/src/synapse_mcp/connection_auth.py
@@ -138,7 +138,7 @@ async def get_synapse_client(ctx: Context) -> synapseclient.Synapse:
             "Authentication for connection needed (or re-authentication for expired sessions).")
 
     # Store client in connection context (not JSON-serializable)
-    await _set_state(ctx, SYNAPSE_CLIENT_KEY, client, serializable=False)
+    # Store client in request-scoped context (not JSON-serializable)
     await _set_state(ctx, AUTH_INITIALIZED_KEY, True, serializable=False)
 
     logger.info(

--- a/src/synapse_mcp/connection_auth.py
+++ b/src/synapse_mcp/connection_auth.py
@@ -91,7 +91,7 @@ async def _set_state(ctx: Context, key: str, value: Any, serializable: bool = Tr
                      type(ctx).__name__, key)
         return
     try:
-        await setter(key, value, serializable)
+        await setter(key, value, serializable=serializable)
     except (TypeError, AttributeError) as exc:
         logger.debug("Context %s rejected set_state for %s: %s",
                      type(ctx).__name__, key, exc)
@@ -139,7 +139,7 @@ async def get_synapse_client(ctx: Context) -> synapseclient.Synapse:
 
     # Store client in connection context (not JSON-serializable)
     await _set_state(ctx, SYNAPSE_CLIENT_KEY, client, serializable=False)
-    await _set_state(ctx, AUTH_INITIALIZED_KEY, True)
+    await _set_state(ctx, AUTH_INITIALIZED_KEY, True, serializable=False)
 
     logger.info(
         "Successfully created and authenticated synapseclient for connection")
@@ -208,7 +208,7 @@ async def _authenticate_with_oauth(client: synapseclient.Synapse, ctx: Context, 
             "method": "oauth",
             "user_id": profile.get("ownerId"),
             "username": profile.get("userName"),
-        })
+        }, serializable=False)
 
         logger.info(
             f"OAuth authentication successful for user: {profile.get('userName')}")
@@ -246,7 +246,7 @@ async def _authenticate_with_pat(client: synapseclient.Synapse, ctx: Context, to
             "user_id": profile.get("ownerId"),
             "username": profile.get("userName"),
             "scopes": ["full_access"]  # PATs have full access
-        })
+        }, serializable=False)
 
         logger.info(
             f"PAT authentication successful for user: {profile.get('userName')}")

--- a/tests/test_connection_auth.py
+++ b/tests/test_connection_auth.py
@@ -16,21 +16,46 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+def _clear_session_store():
+    DummyContext._session_store.clear()
+
+
 class DummyContext:
-    def __init__(self, oauth_token=None):
-        self._state = {}
-        self.session_id = "session-1"
-        # Middleware would have set the oauth_access_token in context
+    """Context stand-in mirroring FastMCP's request- vs session-scoped state.
+
+    ``serializable=False`` values land in a per-instance request-scoped dict;
+    ``serializable=True`` values land in a ``session_id``-keyed store. ``set_state``
+    takes ``serializable`` keyword-only, matching FastMCP's real signature, so a
+    positional call raises instead of silently passing.
+    """
+
+    _session_store: dict = {}
+
+    def __init__(self, oauth_token=None, session_id="session-1"):
+        self.session_id = session_id
+        self._request_state = {}
+        # Middleware would have set the oauth_access_token in context. It does
+        # so request-scoped (serializable=False), same as production.
         if oauth_token:
-            self._state["oauth_access_token"] = oauth_token
+            self._request_state["oauth_access_token"] = oauth_token
+
+    def _session_key(self, key):
+        return f"{self.session_id}:{key}"
 
     async def get_state(self, key):
-        if key in self._state:
-            return self._state[key]
+        if key in self._request_state:
+            return self._request_state[key]
+        session_key = self._session_key(key)
+        if session_key in self._session_store:
+            return self._session_store[session_key]
         raise KeyError
 
-    async def set_state(self, key, value, serializable=True):
-        self._state[key] = value
+    async def set_state(self, key, value, *, serializable=True):
+        if serializable:
+            self._session_store[self._session_key(key)] = value
+        else:
+            self._request_state[key] = value
 
 
 @pytest.fixture
@@ -64,3 +89,7 @@ async def test_oauth_authentication_uses_token_from_context(patched_synapse):
     assert patched_synapse[0].logged_in == "token-abc"
     assert await connection_auth._get_state(ctx, connection_auth.SYNAPSE_CLIENT_KEY) is client
     assert await connection_auth._get_state(ctx, "oauth_access_token") == "token-abc"
+
+    # The client is cached request-scoped, never in the shared session store.
+    assert ctx._request_state[connection_auth.SYNAPSE_CLIENT_KEY] is client
+    assert ctx._session_key(connection_auth.SYNAPSE_CLIENT_KEY) not in DummyContext._session_store

--- a/tests/test_multi_user_isolation.py
+++ b/tests/test_multi_user_isolation.py
@@ -15,14 +15,40 @@ def anyio_backend():
 
 
 class DummyContext:
-    def __init__(self):
-        self._state = {}
+    """Context stand-in mirroring FastMCP's request- vs session-scoped state.
+
+    ``serializable=False`` values land in a per-instance request-scoped dict.
+    ``serializable=True`` values land in a process-global store keyed by
+    ``session_id`` — the same store two requests would share if they present
+    the same ``mcp-session-id`` header.
+
+    ``set_state`` takes ``serializable`` keyword-only, matching FastMCP's real
+    signature, so a positional call raises instead of silently passing.
+    """
+
+    _session_store: dict = {}
+    _counter = 0
+
+    def __init__(self, session_id=None):
+        if session_id is None:
+            DummyContext._counter += 1
+            session_id = f"req-{DummyContext._counter}"
+        self.session_id = session_id
+        self._request_state = {}
+
+    def _session_key(self, key):
+        return f"{self.session_id}:{key}"
 
     async def get_state(self, key, default=None):
-        return self._state.get(key, default)
+        if key in self._request_state:
+            return self._request_state[key]
+        return self._session_store.get(self._session_key(key), default)
 
-    async def set_state(self, key, value, serializable=True):
-        self._state[key] = value
+    async def set_state(self, key, value, *, serializable=True):
+        if serializable:
+            self._session_store[self._session_key(key)] = value
+        else:
+            self._request_state[key] = value
 
 
 def _make_client(user_id: str):
@@ -45,6 +71,7 @@ def _make_client(user_id: str):
 @pytest.fixture(autouse=True)
 def clear_env(monkeypatch):
     monkeypatch.delenv("SYNAPSE_PAT", raising=False)
+    DummyContext._session_store.clear()
 
 
 async def test_get_synapse_client_creates_connection_scoped_clients(monkeypatch):
@@ -121,3 +148,57 @@ async def test_given_two_connections_when_service_called_then_each_gets_own_clie
             assert c1 is not c2
             assert c1._user == "user1"
             assert c2._user == "user2"
+
+
+async def test_auth_state_is_request_scoped_not_session_scoped(monkeypatch):
+    """Two requests sharing an mcp-session-id must not cross auth state.
+
+    The synapseclient, user_auth_info, and auth_initialized flag are stored
+    request-scoped (serializable=False), so nothing lands in the process-global
+    session store that a colliding session_id could read.
+    """
+    ctx1 = DummyContext(session_id="shared-session")
+    ctx2 = DummyContext(session_id="shared-session")
+
+    # Token is injected request-scoped, as the middleware now does.
+    await ctx1.set_state("synapse_pat_token", "fake-pat", serializable=False)
+    await ctx2.set_state("synapse_pat_token", "fake-pat", serializable=False)
+
+    clients = [_make_client("user1"), _make_client("user2")]
+    monkeypatch.setattr(
+        connection_auth.synapseclient,
+        "Synapse",
+        lambda *args, **kwargs: clients.pop(0),
+    )
+
+    client1 = await connection_auth.get_synapse_client(ctx1)
+    client2 = await connection_auth.get_synapse_client(ctx2)
+
+    assert client1 is not client2
+    assert (await get_user_auth_info(ctx1))["user_id"] == "user1"
+    assert (await get_user_auth_info(ctx2))["user_id"] == "user2"
+
+    # No per-request auth state leaked into the shared session store.
+    for key in (
+        "synapse_client",
+        "user_auth_info",
+        "auth_initialized",
+        "synapse_pat_token",
+    ):
+        assert f"shared-session:{key}" not in DummyContext._session_store
+
+
+async def test_set_state_passes_serializable_by_keyword():
+    """_set_state must pass serializable by keyword (FastMCP made it kw-only)."""
+
+    class KeywordOnlyContext:
+        def __init__(self):
+            self.calls = []
+
+        async def set_state(self, key, value, *, serializable=True):
+            self.calls.append((key, value, serializable))
+
+    ctx = KeywordOnlyContext()
+    await connection_auth._set_state(ctx, "k", "v", serializable=False)
+
+    assert ctx.calls == [("k", "v", False)]


### PR DESCRIPTION
## Context

The server runs on AWS with multiple users hitting one process concurrently, and write operations (create/update/delete) are about to be added. This surfaced two related defects in how per-request auth state is stored on the FastMCP `Context` — low-impact for the current read-only catalog, but correctness/security problems once writes exist.

## Defect 1 — token stored in the process-global session store (collision risk)

The middleware stored the token via `set_state("oauth_access_token", token)` with the default `serializable=True`, which routes to `fastmcp._state_store` — a **process-global** `MemoryStore` (`app.py` constructs `FastMCP(...)` with no `session_state_store`; the Redis store backs only the OAuth proxy, not this store). The key is `f"{session_id}:oauth_access_token"`, and `Context.session_id` reads the client-supplied `mcp-session-id` **header** directly — even in stateless mode, which never strips or validates it. Two concurrent requests presenting the same `mcp-session-id` share the same token slot → a request could act under another user's identity. Today we're protected only by clients happening not to send that header.

**Fix:** store the token (and `user_auth_info`, `auth_initialized`) with `serializable=False`, routing them to the request-scoped `_request_state` dict that is discarded when the request ends. The middleware and tool share one `Context` per request, so request-scoped state written in the middleware stays readable in `connection_auth` within the same request. Nothing reads this state across requests, so nothing is lost — every request already carries its own bearer token and rebuilds its own client.

## Defect 2 — `_set_state` passed `serializable` positionally (silently swallowed)

FastMCP's `Context.set_state(self, key, value, *, serializable=True)` makes `serializable` **keyword-only**. `connection_auth._set_state` called `setter(key, value, serializable)` positionally → `TypeError` → silently caught. Consequences in production:

- The client was never persisted, so `get_synapse_client` re-logged in on every `synapse_client(ctx)` within a request (perf).
- `user_auth_info` / `auth_initialized` were never persisted → `has_scope()`, `is_authenticated()`, `require_authentication()`, `get_user_auth_info()` all behaved as unauthenticated. Invisible today (no read tool gates on them), but **write tools gating on scope/auth would be permanently denied.**

**Fix:** pass `serializable=serializable` by keyword.

## Tests

- Tightened `DummyContext` in `tests/test_multi_user_isolation.py` to model FastMCP's request- vs session-scoped storage with a **keyword-only** `serializable` — so the existing tests now catch the positional-arg bug.
- Added `test_auth_state_is_request_scoped_not_session_scoped`: two contexts sharing an `mcp-session-id` get their own token/`user_auth_info`; the shared session store never receives any auth state.
- Added `test_set_state_passes_serializable_by_keyword`.
- Both new tests (and the two tightened existing tests) fail on the prior code and pass with the fix. Full suite: 308 passed.
