### PR TITLE
Fix oauth by adding modify scope

### DIFF
--- a/src/synapse_mcp/app.py
+++ b/src/synapse_mcp/app.py
@@ -36,7 +36,7 @@ class _OAuthFixupMiddleware:
     def __init__(self, app):
         self.app = app
 
-    SUPPORTED_SCOPES = {"openid", "view"}
+    SUPPORTED_SCOPES = {"openid", "view", "modify"}
 
     async def __call__(self, scope, receive, send):
         if scope["type"] != "http":

--- a/tests/test_oauth_fixup_middleware.py
+++ b/tests/test_oauth_fixup_middleware.py
@@ -9,6 +9,9 @@ from synapse_mcp.app import _OAuthFixupMiddleware
 
 pytestmark = pytest.mark.anyio
 
+# Expected sorted scopes_supported list
+SCOPES_SUPPORTED = ["modify", "openid", "view"]
+
 
 @pytest.fixture
 def anyio_backend():
@@ -83,7 +86,7 @@ class TestHandleMetadata:
 
         _, data = await _invoke_metadata(middleware)
 
-        assert data["scopes_supported"] == ["openid", "view"]
+        assert data["scopes_supported"] == SCOPES_SUPPORTED
 
     async def test_preserves_existing_scopes_supported(self):
         """If upstream already has scopes_supported, don't overwrite it."""
@@ -121,7 +124,7 @@ class TestHandleMetadata:
 
         _, data = await _invoke_metadata(middleware)
 
-        assert data["scopes_supported"] == ["openid", "view"]
+        assert data["scopes_supported"] == SCOPES_SUPPORTED
         assert "none" in data["token_endpoint_auth_methods_supported"]
 
     async def test_content_length_updated(self):
@@ -181,7 +184,7 @@ class TestPathScopedMetadataAlias:
         )
 
         assert data["issuer"] == "https://auth.example.com"
-        assert data["scopes_supported"] == ["openid", "view"]
+        assert data["scopes_supported"] == SCOPES_SUPPORTED
         assert "none" in data[
             "token_endpoint_auth_methods_supported"
         ]


### PR DESCRIPTION
# **Problem:**

Write tools (for example create_entity) always fail with a 403 error when the server runs in OAuth mode:

```
{"error": "403 Client Error: insufficient_scope. Request lacks scope(s) required by this service: modify", ...}
```

Reproduced against the deployed staging MCP server from Claude Code: authenticate over OAuth, then call `call_write_tool` -> `create_entity` to create a folder. Every write call returns the 403 above; read tools work.

Root cause: `_OAuthFixupMiddleware.SUPPORTED_SCOPES` in `src/synapse_mcp/app.py` was `{"openid", "view"}`. That constant drives three things:

1. The scopes stripped from `POST /register` bodies.
2. The scopes stripped from the `GET /authorize` query string.
3. The `scopes_supported` list advertised in the authorization-server metadata, which MCP clients read to decide which scopes to request.

So no client could ever obtain a token with the `modify` scope, and Synapse rejects every write with `insufficient_scope`. The DPE-1757 write tools were unreachable over OAuth.

# **Solution:**

Add `modify` to `SUPPORTED_SCOPES`:

```python
SUPPORTED_SCOPES = {"openid", "view", "modify"}
```

Everything else follows from the one constant: the middleware stops stripping `modify` from `/register` and `/authorize`, and the metadata advertises it so clients request it during authorization. The Synapse consent screen then asks the user to grant the modify permission.


# **Testing:**

- Updated `tests/test_oauth_fixup_middleware.py` for the new sorted `scopes_supported` list, extracted into a module-level `SCOPES_SUPPORTED` constant. Kept as a literal (not derived from the middleware constant) so the tests still catch accidental changes to `SUPPORTED_SCOPES`.


