### PR TITLE
fix oauth by adding modify permission

### DIFF
--- a/src/synapse_mcp/oauth/factory.py
+++ b/src/synapse_mcp/oauth/factory.py
@@ -87,6 +87,7 @@ def create_oauth_proxy(env: Optional[dict[str, str]] = None):
         token_verifier=jwt_verifier,
         base_url=settings.server_url,
         client_storage=client_storage,
+        valid_scopes=["openid", "view", "modify"],
     )
 
     return auth


### PR DESCRIPTION
# **Problem:**

Write tools fail with `403 insufficient_scope` (`Request lacks scope(s) required by this service: modify`) even after v0.9.1 added `modify` to the OAuth fixup middleware's `SUPPORTED_SCOPES` (#49) and was deployed to staging.

Reproduced by calling `create_entity` through `call_write_tool` against `mcp-stage.synapse.org` after a fresh re-authentication — the access token never contains the `modify` scope.

Root cause: FastMCP's `OAuthProxy` builds the `/.well-known/oauth-authorization-server` metadata itself and populates `scopes_supported` from `valid_scopes`, which defaults to the token verifier's `required_scopes` (`["openid", "view"]` in `factory.py`). Because `scopes_supported` is therefore always present, the middleware's inject-only-if-missing fallback in `app.py` never fires, so the server keeps advertising only `openid view`. Clients derive the scopes they request from that metadata, so they never ask for `modify`, and the middleware whitelist change in #49 (necessary, but not sufficient) has nothing to let through.

# **Solution:**

Pass `valid_scopes=["openid", "view", "modify"]` explicitly to `SessionAwareOAuthProxy` in `create_oauth_proxy` so the advertised `scopes_supported` includes `modify` and clients request it during registration/authorization.

The verifier's `required_scopes` stays at `["openid", "view"]` on purpose: it is the minimum a token must carry to be accepted at all, and adding `modify` there would 401 every existing read-only client.

Debugged by tracing `scopes_supported` through `fastmcp/server/auth/oauth_proxy/proxy.py` (`valid_scopes or token_verifier.required_scopes`) and `fastmcp/server/auth/auth.py` (metadata built from `client_registration_options.valid_scopes`), then confirming the deployed v0.9.1 staging server still returns `"scopes_supported": ["openid", "view"]`.

No impact beyond the immediate problem: read-only clients keep working, and `SessionAwareOAuthProxy` forwards `**kwargs` to `OAuthProxy` unchanged.

# **Testing:**

- Full test suite passes locally: `uv run pytest` — 344 passed.
- After merge/release/deploy, verify `curl https://mcp-stage.synapse.org/.well-known/oauth-authorization-server` returns `"scopes_supported": ["modify", "openid", "view"]`, then re-authenticate an MCP client and confirm a write tool (e.g. `create_entity`) succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
