### PR TITLE
Bump fastmcp to 3.4.7 to fix modify scope registration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
 dependencies = [
-    "fastmcp==3.2.3",
+    "fastmcp==3.4.7",
     "mcp>=1.28.1,<2",
     "requests>=2.33.0,<3",
     "synapseclient==4.12.0",

--- a/uv.lock
+++ b/uv.lock
@@ -614,34 +614,65 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.2.3"
+version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "fastmcp-slim", extra = ["client", "server"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/dd/fd444d94ae7afdaf5b6dd168799d34023f576b405872d6a27d5686a9d1f4/fastmcp-3.4.7.tar.gz", hash = "sha256:43117aca886f5ee2f6a569bba91cef02b59c339aad04ba29950ff18d251c822a", size = 28808982, upload-time = "2026-08-10T21:17:55.045Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/14/6d950459cc831fa17fe2d1797926b6eb2d2f2af50f830e62d0c098cc1ec8/fastmcp-3.4.7-py3-none-any.whl", hash = "sha256:e4e7698cb4af5bc667b1901685261fa2f3526dc73d243a461fca42500c8dbe56", size = 8016, upload-time = "2026-08-10T21:17:51.391Z" },
+]
+
+[[package]]
+name = "fastmcp-slim"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/ac/7924e803368d0758ee4d6b1259066550df78f58f0f9f8bfebd5a123e957d/fastmcp_slim-3.4.7.tar.gz", hash = "sha256:06b32a358320a7dc2b2ee040ba89ea55ddc20763dff2949f384f7974b13b5d8f", size = 594357, upload-time = "2026-08-10T21:17:28.723Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/97/e0e53642cd029a9a7635ae9c548f9f2cc995af5914e487b3df795664e4be/fastmcp_slim-3.4.7-py3-none-any.whl", hash = "sha256:6c931a0089705f3f2935428ef9b2bc74ad94140adc64aab84d116d103e694b3a", size = 769370, upload-time = "2026-08-10T21:17:27.227Z" },
+]
+
+[package.optional-dependencies]
+client = [
+    { name = "authlib" },
+    { name = "exceptiongroup" },
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "opentelemetry-api" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "starlette" },
+]
+server = [
     { name = "authlib" },
     { name = "cyclopts" },
     { name = "exceptiongroup" },
+    { name = "griffelib" },
     { name = "httpx" },
+    { name = "joserfc" },
     { name = "jsonref" },
     { name = "jsonschema-path" },
     { name = "mcp" },
     { name = "openapi-pydantic" },
     { name = "opentelemetry-api" },
     { name = "packaging" },
-    { name = "platformdirs" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
-    { name = "pydantic", extra = ["email"] },
     { name = "pyperclip" },
-    { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
-    { name = "rich" },
+    { name = "starlette" },
     { name = "uncalled-for" },
     { name = "uvicorn" },
     { name = "watchfiles" },
     { name = "websockets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/42/7eed0a38e3b7a386805fecacf8a5a9353a2b3040395ef9e30e585d8549ac/fastmcp-3.2.3.tar.gz", hash = "sha256:4f02ae8b00227285a0cf6544dea1db29b022c8cdd8d3dfdec7118540210ae60a", size = 26328743, upload-time = "2026-04-09T22:05:03.402Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/48/84b6dcba793178a44b9d99b4def6cd62f870dcfc5bb7b9153ac390135812/fastmcp-3.2.3-py3-none-any.whl", hash = "sha256:cc50af6eed1f62ed8b6ebf4987286d8d1d006f08d5bec739d5c7fb76160e0911", size = 707260, upload-time = "2026-04-09T22:05:01.225Z" },
 ]
 
 [[package]]
@@ -663,6 +694,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/b4/a767e91c606deefc447a96eaf59edd77397960b1d677dffd833ee8449831/griffelib-2.2.0.tar.gz", hash = "sha256:e1bc36fe9cd21d4b6b659b456346755e4cfdc5676c0a5214083126ee12612b3c", size = 227048, upload-time = "2026-08-16T14:04:58.383Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/b6/f65ac785d4ac90dcf7c831ac6256f5dd4a19780f4e1575b2c0d6eeebe319/griffelib-2.2.0-py3-none-any.whl", hash = "sha256:d71c3bc2bbed9f958488634fe788b843a9f705d6d2838ca32cd6c25eeb64dfc4", size = 166779, upload-time = "2026-08-16T14:04:54.365Z" },
 ]
 
 [[package]]
@@ -2073,7 +2113,7 @@ dev = [
 requires-dist = [
     { name = "authlib", specifier = ">=1.6.12,<2" },
     { name = "cryptography", specifier = ">=50.0.0,<51" },
-    { name = "fastmcp", specifier = "==3.2.3" },
+    { name = "fastmcp", specifier = "==3.4.7" },
     { name = "idna", specifier = ">=3.15,<4" },
     { name = "mcp", specifier = ">=1.28.1,<2" },
     { name = "pandas", specifier = ">=1.5.0" },


### PR DESCRIPTION
# **Problem:**

Even after #49 and #50 added `modify` to the middleware's `SUPPORTED_SCOPES` and to `SessionAwareOAuthProxy`'s `valid_scopes`, freshly-registered clients on `mcp-stage.synapse.org` still fail authentication with:

```
invalid_scope: Client was not registered with scope modify
```

Root cause: `fastmcp` 3.2.3's `OAuthProxy.__init__` builds `_default_scope_str` — the scope assigned to a client that omits `scope` from its `POST /register` body — from the JWT verifier's `required_scopes` (`openid`, `view`) instead of `valid_scopes`:

```python
self._default_scope_str: str = " ".join(self.required_scopes or [])
```

`required_scopes` is intentionally kept narrow (`openid`, `view`) so existing read-only tokens keep validating; `valid_scopes` is the wider list (`openid`, `view`, `modify`) that also drives the `.well-known/oauth-authorization-server` metadata's `scopes_supported`. Since most MCP clients (including Claude Code) don't send an explicit `scope` during DCR, they get locked into the `required_scopes`-derived default and are missing `modify` — then `/authorize` rejects the `modify` scope it advertised via metadata, against the client's own stale registration.

# **Solution:**

Bump `fastmcp` from `3.2.3` to `3.4.7`. The fix landed in `3.2.4` ([jlowin/fastmcp#3836](https://github.com/PrefectHQ/fastmcp/pull/3836), "Fix CIMD clients getting required_scopes instead of valid_scopes"):

```python
self._default_scope_str: str = " ".join(
    valid_scopes or self.required_scopes or []
)
```

Despite the CIMD-focused title, this is the same `_default_scope_str` field used by regular DCR client registration, so the fix applies here too. Confirmed no revert in 3.3.x/3.4.x release notes between 3.2.4 and 3.4.7.

3.4.7 is the latest release on the 3.x line (avoiding the `4.0.0` alpha/beta line for now). `uv lock` also picked up transitive bumps (`mcp` 1.27.0 → 1.29.0, `cryptography` 49 → 50, `setuptools` 82 → 84).

# **Testing:**

- `uv lock` + `uv sync` regenerated the lockfile cleanly with no dependency conflicts.
- `uv run pytest` — 432 passed.
- Manual follow-up after deploy: re-register a fresh MCP client against `mcp-stage.synapse.org` and confirm `/authorize` no longer raises `invalid_scope` for `modify`, then confirm a write tool (e.g. `create_entity`) succeeds end-to-end.